### PR TITLE
fix: post-merge TUI bugs — empty state crash, category names in history

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "tsc",
     "postbuild": "chmod +x dist/cli.js",
+    "install-local": "npm run build && npm link",
     "dev": "tsx src/cli.ts",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,5 +1,5 @@
 import React, { useReducer, useEffect } from 'react';
-import { Box, useInput, useApp } from 'ink';
+import { Box, Text, useInput, useApp } from 'ink';
 import type Database from 'better-sqlite3';
 import type * as ynab from 'ynab';
 import type { Config } from '../config.js';
@@ -93,11 +93,11 @@ export function App({ db, api, config }: Props) {
   };
 
   if (state.queue.length === 0) {
-    return <Box><Box>No unapproved transactions. You're all caught up.</Box></Box>;
+    return <Box><Text>No unapproved transactions. You're all caught up.</Text></Box>;
   }
 
   if (!currentTx) {
-    return <Box><Box>Queue complete.</Box></Box>;
+    return <Box><Text>Queue complete.</Text></Box>;
   }
 
   return (
@@ -113,6 +113,7 @@ export function App({ db, api, config }: Props) {
         <DefaultMode
           transaction={currentTx}
           history={payeeHistory}
+          categories={categories}
           suggestedCategoryName={suggestedCategory?.name ?? null}
           writeStatus={state.writeStatus}
         />

--- a/src/tui/DefaultMode.tsx
+++ b/src/tui/DefaultMode.tsx
@@ -3,21 +3,24 @@ import { Box, Text } from 'ink';
 import { formatMilliunits } from '../format.js';
 import type { TransactionRow } from '../db/transactions.js';
 import type { HistoryRow } from '../db/history.js';
+import type { CategoryRow } from '../db/categories.js';
 import type { WriteStatus } from './reducer.js';
 
 interface Props {
   transaction: TransactionRow;
   history: HistoryRow[];
+  categories: CategoryRow[];
   suggestedCategoryName: string | null;
   writeStatus: WriteStatus;
 }
 
 // Main transaction view shown in default mode.
 // Displays transaction details, payee history, suggested category, and keybind hints.
-export function DefaultMode({ transaction, history, suggestedCategoryName, writeStatus }: Props) {
+export function DefaultMode({ transaction, history, categories, suggestedCategoryName, writeStatus }: Props) {
   const amount = formatMilliunits(transaction.amount);
   const isInflow = transaction.amount > 0;
   const totalHistory = history.reduce((sum, h) => sum + h.count, 0);
+  const categoryName = (id: string) => categories.find((c) => c.id === id)?.name ?? id;
 
   return (
     <Box flexDirection="column">
@@ -38,7 +41,7 @@ export function DefaultMode({ transaction, history, suggestedCategoryName, write
               const pct = Math.round((h.count / totalHistory) * 100);
               return (
                 <Text key={h.category_id}>
-                  {'  '}{h.category_id.padEnd(20)} {String(pct).padStart(3)}%  ({h.count})
+                  {'  '}{categoryName(h.category_id).padEnd(30)} {String(pct).padStart(3)}%  ({h.count})
                 </Text>
               );
             })}

--- a/tests/tui-snapshots.test.tsx
+++ b/tests/tui-snapshots.test.tsx
@@ -8,6 +8,7 @@ import { ErrorBanner } from '../src/tui/ErrorBanner.js';
 import { DefaultMode } from '../src/tui/DefaultMode.js';
 import type { TransactionRow } from '../src/db/transactions.js';
 import type { HistoryRow } from '../src/db/history.js';
+import type { CategoryRow } from '../src/db/categories.js';
 
 const tx: TransactionRow = {
   id: 'tx1',
@@ -28,6 +29,11 @@ const tx: TransactionRow = {
 const history: HistoryRow[] = [
   { payee_id: 'p1', category_id: 'c1', count: 26, last_used: '2026-04-01' },
   { payee_id: 'p1', category_id: 'c2', count: 11, last_used: '2026-03-01' },
+];
+
+const categories: CategoryRow[] = [
+  { id: 'c1', name: 'Groceries', group_name: 'Food', hidden: 0, deleted: 0 },
+  { id: 'c2', name: 'Household', group_name: 'Home', hidden: 0, deleted: 0 },
 ];
 
 describe('TUI snapshots', () => {
@@ -64,6 +70,7 @@ describe('TUI snapshots', () => {
       React.createElement(DefaultMode, {
         transaction: tx,
         history,
+        categories,
         suggestedCategoryName: 'Groceries',
         writeStatus: 'idle',
       })
@@ -71,6 +78,7 @@ describe('TUI snapshots', () => {
     expect(lastFrame()).toContain('TARGET');
     expect(lastFrame()).toContain('-$84.22');
     expect(lastFrame()).toContain('Suggested');
+    expect(lastFrame()).toContain('Groceries');
   });
 
   it('DefaultMode renders no-history message when history is empty', () => {
@@ -78,6 +86,7 @@ describe('TUI snapshots', () => {
       React.createElement(DefaultMode, {
         transaction: tx,
         history: [],
+        categories,
         suggestedCategoryName: null,
         writeStatus: 'idle',
       })


### PR DESCRIPTION
## Summary

- Fix crash when queue is empty: raw strings were inside `<Box>` instead of `<Text>` — Ink requires all text nodes to be wrapped in `<Text>`
- Fix history display showing UUIDs instead of category names: pass `categories` prop to `DefaultMode` and resolve names via lookup
- Add `install-local` npm script (`npm run build && npm link`) for one-step local install

## Acceptance Criteria

- [x] `ynab-blaster` launches without the "Text string must be rendered inside `<Text>` component" error when the transaction queue is empty
  - *Verify: run `ynab-blaster` with no unapproved transactions — should print "You're all caught up." cleanly*
- [x] History section shows category names (e.g. "Groceries") instead of UUIDs
  - *Verify: in the TUI, the history list next to percentages shows readable names, not `4a384b9e-...` style IDs*
- [x] `npm run install-local` builds and links the binary in one step
  - *Verify: run `npm run install-local` — it compiles TypeScript and makes `ynab-blaster` available globally*

Closes #5