### PR TITLE
feat: YNAB-style grouped category picker with Available balances

### DIFF
--- a/src/db/categories.ts
+++ b/src/db/categories.ts
@@ -42,9 +42,16 @@ export function getCategories(
   return db.prepare(sql).all() as CategoryRow[];
 }
 
+// Group names that YNAB treats as system/internal and that we pin to the top
+// of the picker so they appear in the same position as in the YNAB web UI.
+// Preserving array order defines the pin order.
+const PINNED_GROUPS: string[] = ['Internal Master Category'];
+
 // Returns visible (non-hidden, non-deleted) categories grouped by group_name.
 // `null` groups fall under the literal "Uncategorized" bucket. The picker view
-// always hides hidden categories regardless of config.
+// always hides hidden categories regardless of config. Pinned groups (see
+// PINNED_GROUPS) are moved to the top, preserving their relative pin order;
+// remaining groups keep the alphabetical order from getCategories().
 export function getVisibleCategoriesGrouped(db: Database.Database): CategoryGroup[] {
   const rows = getCategories(db, false);
   const byGroup = new Map<string, CategoryRow[]>();
@@ -54,5 +61,15 @@ export function getVisibleCategoriesGrouped(db: Database.Database): CategoryGrou
     if (bucket) bucket.push(row);
     else byGroup.set(key, [row]);
   }
-  return Array.from(byGroup.entries()).map(([group, categories]) => ({ group, categories }));
+  const pinned: CategoryGroup[] = [];
+  const rest: CategoryGroup[] = [];
+  for (const [group, categories] of byGroup.entries()) {
+    const entry = { group, categories };
+    if (PINNED_GROUPS.includes(group)) pinned.push(entry);
+    else rest.push(entry);
+  }
+  pinned.sort(
+    (a, b) => PINNED_GROUPS.indexOf(a.group) - PINNED_GROUPS.indexOf(b.group)
+  );
+  return [...pinned, ...rest];
 }

--- a/src/db/categories.ts
+++ b/src/db/categories.ts
@@ -6,6 +6,12 @@ export interface CategoryRow {
   group_name: string | null;
   hidden: number;
   deleted: number;
+  balance: number;
+}
+
+export interface CategoryGroup {
+  group: string;
+  categories: CategoryRow[];
 }
 
 // Upserts a batch of categories from a YNAB API response.
@@ -14,8 +20,8 @@ export function upsertCategories(
   categories: CategoryRow[]
 ): void {
   const stmt = db.prepare(`
-    INSERT OR REPLACE INTO categories (id, name, group_name, hidden, deleted)
-    VALUES (@id, @name, @group_name, @hidden, @deleted)
+    INSERT OR REPLACE INTO categories (id, name, group_name, hidden, deleted, balance)
+    VALUES (@id, @name, @group_name, @hidden, @deleted, @balance)
   `);
   const upsertMany = db.transaction((rows: CategoryRow[]) => {
     for (const row of rows) stmt.run(row);
@@ -24,12 +30,29 @@ export function upsertCategories(
 }
 
 // Returns all non-deleted categories, optionally including hidden ones.
+// Ordered by group_name, then name — stable input for the grouped picker.
 export function getCategories(
   db: Database.Database,
   includeHidden: boolean
 ): CategoryRow[] {
-  const sql = includeHidden
-    ? 'SELECT * FROM categories WHERE deleted = 0'
-    : 'SELECT * FROM categories WHERE deleted = 0 AND hidden = 0';
+  const where = includeHidden
+    ? 'WHERE deleted = 0'
+    : 'WHERE deleted = 0 AND hidden = 0';
+  const sql = `SELECT * FROM categories ${where} ORDER BY group_name COLLATE NOCASE, name COLLATE NOCASE`;
   return db.prepare(sql).all() as CategoryRow[];
+}
+
+// Returns visible (non-hidden, non-deleted) categories grouped by group_name.
+// `null` groups fall under the literal "Uncategorized" bucket. The picker view
+// always hides hidden categories regardless of config.
+export function getVisibleCategoriesGrouped(db: Database.Database): CategoryGroup[] {
+  const rows = getCategories(db, false);
+  const byGroup = new Map<string, CategoryRow[]>();
+  for (const row of rows) {
+    const key = row.group_name ?? 'Uncategorized';
+    const bucket = byGroup.get(key);
+    if (bucket) bucket.push(row);
+    else byGroup.set(key, [row]);
+  }
+  return Array.from(byGroup.entries()).map(([group, categories]) => ({ group, categories }));
 }

--- a/src/db/categories.ts
+++ b/src/db/categories.ts
@@ -47,13 +47,16 @@ export function getCategories(
 // Preserving array order defines the pin order.
 const PINNED_GROUPS: string[] = ['Internal Master Category'];
 
-// Returns visible (non-hidden, non-deleted) categories grouped by group_name.
-// `null` groups fall under the literal "Uncategorized" bucket. The picker view
-// always hides hidden categories regardless of config. Pinned groups (see
+// Returns non-deleted categories grouped by group_name, honoring the caller's
+// includeHidden choice (driven by config.include_hidden_categories). `null`
+// groups fall under the literal "Uncategorized" bucket. Pinned groups (see
 // PINNED_GROUPS) are moved to the top, preserving their relative pin order;
 // remaining groups keep the alphabetical order from getCategories().
-export function getVisibleCategoriesGrouped(db: Database.Database): CategoryGroup[] {
-  const rows = getCategories(db, false);
+export function getCategoriesGrouped(
+  db: Database.Database,
+  includeHidden: boolean
+): CategoryGroup[] {
+  const rows = getCategories(db, includeHidden);
   const byGroup = new Map<string, CategoryRow[]>();
   for (const row of rows) {
     const key = row.group_name ?? 'Uncategorized';

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -13,7 +13,8 @@ export function applySchema(db: Database.Database): void {
       name TEXT NOT NULL,
       group_name TEXT,
       hidden INTEGER DEFAULT 0,
-      deleted INTEGER DEFAULT 0
+      deleted INTEGER DEFAULT 0,
+      balance INTEGER NOT NULL DEFAULT 0
     );
 
     CREATE TABLE IF NOT EXISTS payees (
@@ -57,4 +58,10 @@ export function applySchema(db: Database.Database): void {
       created_at TEXT NOT NULL
     );
   `);
+
+  // Migrate pre-existing DBs that were created before the `balance` column existed.
+  const columns = db.prepare(`PRAGMA table_info(categories)`).all() as { name: string }[];
+  if (!columns.some((c) => c.name === 'balance')) {
+    db.exec(`ALTER TABLE categories ADD COLUMN balance INTEGER NOT NULL DEFAULT 0`);
+  }
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -60,8 +60,11 @@ export function applySchema(db: Database.Database): void {
   `);
 
   // Migrate pre-existing DBs that were created before the `balance` column existed.
+  // Clear server_knowledge so the next sync is a full re-fetch — delta sync alone
+  // would leave the DEFAULT 0 balance untouched for unchanged categories.
   const columns = db.prepare(`PRAGMA table_info(categories)`).all() as { name: string }[];
   if (!columns.some((c) => c.name === 'balance')) {
     db.exec(`ALTER TABLE categories ADD COLUMN balance INTEGER NOT NULL DEFAULT 0`);
+    db.prepare(`DELETE FROM meta WHERE key = 'server_knowledge'`).run();
   }
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -60,11 +60,22 @@ export function applySchema(db: Database.Database): void {
   `);
 
   // Migrate pre-existing DBs that were created before the `balance` column existed.
-  // Clear server_knowledge so the next sync is a full re-fetch — delta sync alone
-  // would leave the DEFAULT 0 balance untouched for unchanged categories.
   const columns = db.prepare(`PRAGMA table_info(categories)`).all() as { name: string }[];
   if (!columns.some((c) => c.name === 'balance')) {
     db.exec(`ALTER TABLE categories ADD COLUMN balance INTEGER NOT NULL DEFAULT 0`);
+  }
+
+  // One-time: after introducing `balance`, force the next sync to be a full re-fetch
+  // so every row's balance populates. Delta sync would leave unchanged rows at
+  // DEFAULT 0. Guarded by a meta flag so it runs exactly once per DB — covers both
+  // fresh installs and users who already applied the v1 migration without this step.
+  const backfillFlag = db
+    .prepare(`SELECT value FROM meta WHERE key = 'balance_backfill_v1'`)
+    .get() as { value: string } | undefined;
+  if (!backfillFlag) {
     db.prepare(`DELETE FROM meta WHERE key = 'server_knowledge'`).run();
+    db.prepare(
+      `INSERT OR REPLACE INTO meta (key, value) VALUES ('balance_backfill_v1', '1')`
+    ).run();
   }
 }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -39,6 +39,7 @@ export async function syncFromYnab(
       group_name: group.name,
       hidden: cat.hidden ? 1 : 0,
       deleted: cat.deleted ? 1 : 0,
+      balance: cat.balance ?? 0,
     }))
   );
 

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -13,7 +13,7 @@ import { ErrorBanner } from './ErrorBanner.js';
 import { WriteStatus } from './WriteStatus.js';
 import { WriteManager } from '../write-manager.js';
 import { getUnapprovedTransactions } from '../db/transactions.js';
-import { getCategories } from '../db/categories.js';
+import { getCategories, getVisibleCategoriesGrouped } from '../db/categories.js';
 import { getPayeeHistory } from '../db/history.js';
 
 interface Props {
@@ -30,6 +30,7 @@ export function App({ db, api, config }: Props) {
 
   const manager = new WriteManager(db, api, config.budget_id);
   const categories = getCategories(db, config.include_hidden_categories);
+  const categoryGroups = getVisibleCategoriesGrouped(db);
 
   // Load unapproved queue on mount.
   useEffect(() => {
@@ -121,7 +122,7 @@ export function App({ db, api, config }: Props) {
 
       {state.mode === 'picker' && (
         <CategoryPicker
-          categories={categories}
+          groups={categoryGroups}
           onSelect={handleCategorySelect}
           onCancel={() => dispatch({ type: 'SET_MODE', mode: 'default' })}
         />

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -13,7 +13,7 @@ import { ErrorBanner } from './ErrorBanner.js';
 import { WriteStatus } from './WriteStatus.js';
 import { WriteManager } from '../write-manager.js';
 import { getUnapprovedTransactions } from '../db/transactions.js';
-import { getCategories, getVisibleCategoriesGrouped } from '../db/categories.js';
+import { getCategories, getCategoriesGrouped } from '../db/categories.js';
 import { getPayeeHistory } from '../db/history.js';
 
 interface Props {
@@ -30,7 +30,7 @@ export function App({ db, api, config }: Props) {
 
   const manager = new WriteManager(db, api, config.budget_id);
   const categories = getCategories(db, config.include_hidden_categories);
-  const categoryGroups = getVisibleCategoriesGrouped(db);
+  const categoryGroups = getCategoriesGrouped(db, config.include_hidden_categories);
 
   // Load unapproved queue on mount.
   useEffect(() => {

--- a/src/tui/CategoryPicker.tsx
+++ b/src/tui/CategoryPicker.tsx
@@ -74,7 +74,12 @@ export function CategoryPicker({ groups, onSelect, onCancel }: Props) {
       ) : (
         filtered.map((g) => (
           <Box key={g.group} flexDirection="column" marginTop={1}>
-            <Text bold color="cyan">{g.group}</Text>
+            <Box>
+              <Box width={NAME_WIDTH + 3} flexShrink={0}>
+                <Text bold color="cyan">{g.group}</Text>
+              </Box>
+              <Text dimColor>Available (this month)</Text>
+            </Box>
             {g.categories.map((c) => {
               const isActive = flatIndex === cursor;
               flatIndex += 1;

--- a/src/tui/CategoryPicker.tsx
+++ b/src/tui/CategoryPicker.tsx
@@ -1,53 +1,96 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
-import SelectInput from 'ink-select-input';
 import TextInput from 'ink-text-input';
 import { fuzzyFilter } from '../fuzzy.js';
-import type { CategoryRow } from '../db/categories.js';
-
-interface Item {
-  label: string;
-  value: string;
-}
+import { formatMilliunits } from '../format.js';
+import type { CategoryGroup, CategoryRow } from '../db/categories.js';
 
 interface Props {
-  categories: CategoryRow[];
+  groups: CategoryGroup[];
   onSelect: (categoryId: string, categoryName: string) => void;
   onCancel: () => void;
 }
 
-// Full-screen category picker. Text input at the top fuzzy-filters the list below.
-// Enter selects, Escape cancels.
-export function CategoryPicker({ categories, onSelect, onCancel }: Props) {
-  const [query, setQuery] = useState('');
+const NAME_WIDTH = 34;
 
-  const filtered = fuzzyFilter(
-    categories.map((c) => c.name),
-    query
+function balanceColor(ms: number): 'green' | 'red' | undefined {
+  if (ms > 0) return 'green';
+  if (ms < 0) return 'red';
+  return undefined;
+}
+
+// Grouped category picker that mimics YNAB's budget-category grid.
+// Each group renders as a bold header with its categories beneath; rows show
+// the Available balance, color-coded by sign. A TextInput at the top fuzzy-
+// filters category names; groups with no matches collapse out of view.
+// Hidden categories are never shown here, regardless of config.
+export function CategoryPicker({ groups, onSelect, onCancel }: Props) {
+  const [query, setQuery] = useState('');
+  const [cursor, setCursor] = useState(0);
+
+  const filtered = useMemo<CategoryGroup[]>(() => {
+    if (!query) return groups.filter((g) => g.categories.length > 0);
+    return groups
+      .map((g) => {
+        const matches = fuzzyFilter(
+          g.categories.map((c) => c.name),
+          query
+        );
+        const matchSet = new Set(matches);
+        return { group: g.group, categories: g.categories.filter((c) => matchSet.has(c.name)) };
+      })
+      .filter((g) => g.categories.length > 0);
+  }, [groups, query]);
+
+  const flatItems = useMemo<CategoryRow[]>(
+    () => filtered.flatMap((g) => g.categories),
+    [filtered]
   );
 
-  const items: Item[] = filtered.map((name) => {
-    const cat = categories.find((c) => c.name === name)!;
-    return { label: name, value: cat.id };
-  });
+  // Clamp the cursor whenever the filtered list changes.
+  useEffect(() => {
+    setCursor(0);
+  }, [flatItems.length]);
 
   useInput((_, key) => {
-    if (key.escape) onCancel();
+    if (key.escape) return onCancel();
+    if (flatItems.length === 0) return;
+    if (key.upArrow) setCursor((c) => Math.max(0, c - 1));
+    if (key.downArrow) setCursor((c) => Math.min(flatItems.length - 1, c + 1));
+    if (key.return) {
+      const pick = flatItems[cursor];
+      if (pick) onSelect(pick.id, pick.name);
+    }
   });
 
-  const handleSelect = (item: Item) => {
-    const cat = categories.find((c) => c.id === item.value)!;
-    onSelect(cat.id, cat.name);
-  };
+  let flatIndex = 0;
 
   return (
     <Box flexDirection="column">
       <Text bold>Select category (Esc to cancel):</Text>
       <TextInput value={query} onChange={setQuery} placeholder="type to filter..." />
-      {items.length > 0 ? (
-        <SelectInput items={items} onSelect={handleSelect} />
-      ) : (
+      {flatItems.length === 0 ? (
         <Text dimColor>No matching categories</Text>
+      ) : (
+        filtered.map((g) => (
+          <Box key={g.group} flexDirection="column" marginTop={1}>
+            <Text bold color="cyan">{g.group}</Text>
+            {g.categories.map((c) => {
+              const isActive = flatIndex === cursor;
+              flatIndex += 1;
+              const balance = formatMilliunits(c.balance).replace(/^\+/, '');
+              const color = balanceColor(c.balance);
+              return (
+                <Text key={c.id} inverse={isActive}>
+                  {'  '}
+                  {c.name.padEnd(NAME_WIDTH)}
+                  {' '}
+                  <Text color={color} dimColor={c.balance === 0}>{balance}</Text>
+                </Text>
+              );
+            })}
+          </Box>
+        ))
       )}
     </Box>
   );

--- a/tests/categories.test.ts
+++ b/tests/categories.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { openDatabase } from '../src/db/client.js';
 import { applySchema } from '../src/db/schema.js';
+import { getMeta, setMeta } from '../src/db/meta.js';
 import {
   getCategories,
   getVisibleCategoriesGrouped,
@@ -47,6 +48,32 @@ describe('getCategories', () => {
     const result = getCategories(db, false);
     const groceries = result.find((r) => r.id === 'c1');
     expect(groceries?.balance).toBe(120000);
+  });
+});
+
+describe('balance column migration', () => {
+  it('clears server_knowledge so the next sync is a full re-fetch', () => {
+    // Simulate a pre-existing DB that has a stored server_knowledge but no balance column.
+    // We do this by creating a DB with the OLD schema (no balance), setting knowledge, then applying the new schema.
+    const oldDb = openDatabase(':memory:');
+    // Create the categories table without the balance column
+    oldDb.exec(`
+      CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+      CREATE TABLE categories (id TEXT PRIMARY KEY, name TEXT NOT NULL, group_name TEXT, hidden INTEGER DEFAULT 0, deleted INTEGER DEFAULT 0);
+    `);
+    setMeta(oldDb, 'server_knowledge', '42');
+
+    // Now apply the new schema — migration should add the column and clear server_knowledge
+    applySchema(oldDb);
+
+    expect(getMeta(oldDb, 'server_knowledge')).toBeUndefined();
+  });
+
+  it('does NOT clear server_knowledge if balance column already exists', () => {
+    // Fresh DB via applySchema already has balance column; server_knowledge should be untouched
+    setMeta(db, 'server_knowledge', '99');
+    applySchema(db); // re-run on already-migrated DB
+    expect(getMeta(db, 'server_knowledge')).toBe('99');
   });
 });
 

--- a/tests/categories.test.ts
+++ b/tests/categories.test.ts
@@ -4,7 +4,7 @@ import { applySchema } from '../src/db/schema.js';
 import { getMeta, setMeta } from '../src/db/meta.js';
 import {
   getCategories,
-  getVisibleCategoriesGrouped,
+  getCategoriesGrouped,
   upsertCategories,
   type CategoryRow,
 } from '../src/db/categories.js';
@@ -92,21 +92,29 @@ describe('balance column migration', () => {
   });
 });
 
-describe('getVisibleCategoriesGrouped', () => {
-  it('always hides hidden categories regardless of config', () => {
-    const groups = getVisibleCategoriesGrouped(db);
+describe('getCategoriesGrouped', () => {
+  it('hides hidden categories when includeHidden=false', () => {
+    const groups = getCategoriesGrouped(db, false);
     const allIds = groups.flatMap((g) => g.categories.map((c) => c.id));
     expect(allIds).not.toContain('c4');
   });
 
+  it('includes hidden categories when includeHidden=true', () => {
+    const groups = getCategoriesGrouped(db, true);
+    const allIds = groups.flatMap((g) => g.categories.map((c) => c.id));
+    expect(allIds).toContain('c4');
+    // Deleted rows are still excluded regardless of includeHidden.
+    expect(allIds).not.toContain('c5');
+  });
+
   it('buckets null group_name under "Uncategorized"', () => {
-    const groups = getVisibleCategoriesGrouped(db);
+    const groups = getCategoriesGrouped(db, false);
     const uncategorized = groups.find((g) => g.group === 'Uncategorized');
     expect(uncategorized?.categories.map((c) => c.id)).toEqual(['c6']);
   });
 
   it('groups categories by group_name and preserves sort within group', () => {
-    const groups = getVisibleCategoriesGrouped(db);
+    const groups = getCategoriesGrouped(db, false);
     const food = groups.find((g) => g.group === 'Food');
     expect(food?.categories.map((c) => c.name)).toEqual(['Dining Out', 'Groceries']);
   });
@@ -122,7 +130,7 @@ describe('getVisibleCategoriesGrouped', () => {
         balance: 28221030,
       },
     ]);
-    const groups = getVisibleCategoriesGrouped(db);
+    const groups = getCategoriesGrouped(db, false);
     expect(groups[0]?.group).toBe('Internal Master Category');
     expect(groups[0]?.categories.map((c) => c.name)).toContain('Inflow: Ready to Assign');
   });

--- a/tests/categories.test.ts
+++ b/tests/categories.test.ts
@@ -110,4 +110,20 @@ describe('getVisibleCategoriesGrouped', () => {
     const food = groups.find((g) => g.group === 'Food');
     expect(food?.categories.map((c) => c.name)).toEqual(['Dining Out', 'Groceries']);
   });
+
+  it('pins "Internal Master Category" to the top of the group list', () => {
+    upsertCategories(db, [
+      {
+        id: 'i1',
+        name: 'Inflow: Ready to Assign',
+        group_name: 'Internal Master Category',
+        hidden: 0,
+        deleted: 0,
+        balance: 28221030,
+      },
+    ]);
+    const groups = getVisibleCategoriesGrouped(db);
+    expect(groups[0]?.group).toBe('Internal Master Category');
+    expect(groups[0]?.categories.map((c) => c.name)).toContain('Inflow: Ready to Assign');
+  });
 });

--- a/tests/categories.test.ts
+++ b/tests/categories.test.ts
@@ -52,27 +52,42 @@ describe('getCategories', () => {
 });
 
 describe('balance column migration', () => {
-  it('clears server_knowledge so the next sync is a full re-fetch', () => {
-    // Simulate a pre-existing DB that has a stored server_knowledge but no balance column.
-    // We do this by creating a DB with the OLD schema (no balance), setting knowledge, then applying the new schema.
+  it('clears server_knowledge on the first applySchema and records a backfill flag', () => {
+    // Simulate a pre-existing DB with the OLD categories schema (no balance column) and a
+    // stored server_knowledge from a previous delta sync.
     const oldDb = openDatabase(':memory:');
-    // Create the categories table without the balance column
     oldDb.exec(`
       CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
       CREATE TABLE categories (id TEXT PRIMARY KEY, name TEXT NOT NULL, group_name TEXT, hidden INTEGER DEFAULT 0, deleted INTEGER DEFAULT 0);
     `);
     setMeta(oldDb, 'server_knowledge', '42');
 
-    // Now apply the new schema — migration should add the column and clear server_knowledge
     applySchema(oldDb);
 
     expect(getMeta(oldDb, 'server_knowledge')).toBeUndefined();
+    expect(getMeta(oldDb, 'balance_backfill_v1')).toBe('1');
   });
 
-  it('does NOT clear server_knowledge if balance column already exists', () => {
-    // Fresh DB via applySchema already has balance column; server_knowledge should be untouched
+  it('clears server_knowledge even when the balance column already exists (v1 migration already ran)', () => {
+    // Simulate a user who ran the buggy v1 migration: balance column present, but
+    // server_knowledge was never cleared and no backfill flag was set.
+    const oldDb = openDatabase(':memory:');
+    oldDb.exec(`
+      CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+      CREATE TABLE categories (id TEXT PRIMARY KEY, name TEXT NOT NULL, group_name TEXT, hidden INTEGER DEFAULT 0, deleted INTEGER DEFAULT 0, balance INTEGER NOT NULL DEFAULT 0);
+    `);
+    setMeta(oldDb, 'server_knowledge', '42');
+
+    applySchema(oldDb);
+
+    expect(getMeta(oldDb, 'server_knowledge')).toBeUndefined();
+    expect(getMeta(oldDb, 'balance_backfill_v1')).toBe('1');
+  });
+
+  it('does NOT clear server_knowledge on subsequent applySchema calls', () => {
+    // db was already migrated in beforeEach, so the flag is set.
     setMeta(db, 'server_knowledge', '99');
-    applySchema(db); // re-run on already-migrated DB
+    applySchema(db);
     expect(getMeta(db, 'server_knowledge')).toBe('99');
   });
 });

--- a/tests/categories.test.ts
+++ b/tests/categories.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { openDatabase } from '../src/db/client.js';
+import { applySchema } from '../src/db/schema.js';
+import {
+  getCategories,
+  getVisibleCategoriesGrouped,
+  upsertCategories,
+  type CategoryRow,
+} from '../src/db/categories.js';
+import type Database from 'better-sqlite3';
+
+let db: Database.Database;
+
+const rows: CategoryRow[] = [
+  { id: 'c1', name: 'Groceries', group_name: 'Food', hidden: 0, deleted: 0, balance: 120000 },
+  { id: 'c2', name: 'Dining Out', group_name: 'Food', hidden: 0, deleted: 0, balance: 0 },
+  { id: 'c3', name: 'Rent', group_name: 'Home', hidden: 0, deleted: 0, balance: -50000 },
+  { id: 'c4', name: 'Secret Stash', group_name: 'Hidden', hidden: 1, deleted: 0, balance: 9999 },
+  { id: 'c5', name: 'Old Thing', group_name: 'Food', hidden: 0, deleted: 1, balance: 0 },
+  { id: 'c6', name: 'Orphan', group_name: null, hidden: 0, deleted: 0, balance: 42 },
+];
+
+beforeEach(() => {
+  db = openDatabase(':memory:');
+  applySchema(db);
+  upsertCategories(db, rows);
+});
+
+describe('getCategories', () => {
+  it('excludes hidden and deleted categories by default', () => {
+    const result = getCategories(db, false);
+    const ids = result.map((r) => r.id);
+    expect(ids).not.toContain('c4');
+    expect(ids).not.toContain('c5');
+    expect(ids).toContain('c1');
+    expect(ids).toContain('c3');
+  });
+
+  it('includes hidden but still excludes deleted when includeHidden=true', () => {
+    const result = getCategories(db, true);
+    const ids = result.map((r) => r.id);
+    expect(ids).toContain('c4');
+    expect(ids).not.toContain('c5');
+  });
+
+  it('persists and returns the balance field', () => {
+    const result = getCategories(db, false);
+    const groceries = result.find((r) => r.id === 'c1');
+    expect(groceries?.balance).toBe(120000);
+  });
+});
+
+describe('getVisibleCategoriesGrouped', () => {
+  it('always hides hidden categories regardless of config', () => {
+    const groups = getVisibleCategoriesGrouped(db);
+    const allIds = groups.flatMap((g) => g.categories.map((c) => c.id));
+    expect(allIds).not.toContain('c4');
+  });
+
+  it('buckets null group_name under "Uncategorized"', () => {
+    const groups = getVisibleCategoriesGrouped(db);
+    const uncategorized = groups.find((g) => g.group === 'Uncategorized');
+    expect(uncategorized?.categories.map((c) => c.id)).toEqual(['c6']);
+  });
+
+  it('groups categories by group_name and preserves sort within group', () => {
+    const groups = getVisibleCategoriesGrouped(db);
+    const food = groups.find((g) => g.group === 'Food');
+    expect(food?.categories.map((c) => c.name)).toEqual(['Dining Out', 'Groceries']);
+  });
+});

--- a/tests/tui-snapshots.test.tsx
+++ b/tests/tui-snapshots.test.tsx
@@ -6,9 +6,10 @@ import { Footer } from '../src/tui/Footer.js';
 import { WriteStatus } from '../src/tui/WriteStatus.js';
 import { ErrorBanner } from '../src/tui/ErrorBanner.js';
 import { DefaultMode } from '../src/tui/DefaultMode.js';
+import { CategoryPicker } from '../src/tui/CategoryPicker.js';
 import type { TransactionRow } from '../src/db/transactions.js';
 import type { HistoryRow } from '../src/db/history.js';
-import type { CategoryRow } from '../src/db/categories.js';
+import type { CategoryGroup, CategoryRow } from '../src/db/categories.js';
 
 const tx: TransactionRow = {
   id: 'tx1',
@@ -32,8 +33,13 @@ const history: HistoryRow[] = [
 ];
 
 const categories: CategoryRow[] = [
-  { id: 'c1', name: 'Groceries', group_name: 'Food', hidden: 0, deleted: 0 },
-  { id: 'c2', name: 'Household', group_name: 'Home', hidden: 0, deleted: 0 },
+  { id: 'c1', name: 'Groceries', group_name: 'Food', hidden: 0, deleted: 0, balance: 245000 },
+  { id: 'c2', name: 'Household', group_name: 'Home', hidden: 0, deleted: 0, balance: -1500 },
+];
+
+const groups: CategoryGroup[] = [
+  { group: 'Food', categories: [categories[0]!] },
+  { group: 'Home', categories: [categories[1]!] },
 ];
 
 describe('TUI snapshots', () => {
@@ -92,5 +98,33 @@ describe('TUI snapshots', () => {
       })
     );
     expect(lastFrame()).toContain('no prior approvals');
+  });
+
+  it('CategoryPicker renders grouped categories with color-coded balances', () => {
+    const { lastFrame } = render(
+      React.createElement(CategoryPicker, {
+        groups,
+        onSelect: () => {},
+        onCancel: () => {},
+      })
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Food');
+    expect(frame).toContain('Home');
+    expect(frame).toContain('Groceries');
+    expect(frame).toContain('Household');
+    expect(frame).toContain('$245.00');
+    expect(frame).toContain('$1.50');
+  });
+
+  it('CategoryPicker shows empty-state message when no groups are provided', () => {
+    const { lastFrame } = render(
+      React.createElement(CategoryPicker, {
+        groups: [],
+        onSelect: () => {},
+        onCancel: () => {},
+      })
+    );
+    expect(lastFrame()).toContain('No matching categories');
   });
 });


### PR DESCRIPTION
## Summary

Rewrites the category picker (opened with `c` during approval) to mimic YNAB's budget category grid. Each category group renders as a bold header and every row shows the current month's **Available** balance, color-coded by sign — so you can see at a glance which envelopes have money before picking one.

## What changed

- **Schema** (`src/db/schema.ts`): adds a `balance` column (milliunits) to `categories` via an idempotent `ALTER TABLE` migration. A one-time `balance_backfill_v1` meta flag forces the next sync to be a full re-fetch after migration, so every row's balance populates (delta sync alone would leave unchanged rows at `DEFAULT 0`).
- **Sync** (`src/sync.ts`): populates `balance` from `cat.balance` (YNAB SDK "Available balance in milliunits") on every sync.
- **Data access** (`src/db/categories.ts`): extends `CategoryRow` with `balance`, orders queries by group/name, and adds `getCategoriesGrouped(db, includeHidden)` — respects `include_hidden_categories` config, buckets null `group_name` under `Uncategorized`, and pins `Internal Master Category` to the top to match the YNAB web UI layout.
- **Picker UI** (`src/tui/CategoryPicker.tsx`, `src/tui/App.tsx`): replaces the flat `ink-select-input` list with a grouped grid. Each group header shows `"Available (this month)"` aligned with the balance column. Fuzzy filter at top collapses empty groups. Custom keyboard cursor (↑/↓/Enter/Esc) skips group headers.

## Acceptance Criteria

- [ ] Pressing `c` during approval opens a picker grouped by YNAB category group, with each group name rendered as a bold cyan header.
- [ ] Each group header shows `"Available (this month)"` as a column label, right-aligned with the balance values below it.
- [ ] Every category row shows the current-month Available balance, color-coded: green when positive, red when negative, dim when zero.
- [ ] `Internal Master Category` group (containing "Inflow: Ready to Assign" etc.) appears at the top, before alphabetically-sorted user groups.
- [ ] Categories within each group are ordered alphabetically (case-insensitive).
- [ ] `include_hidden_categories: false` (default) hides hidden YNAB categories from the picker; `include_hidden_categories: true` shows them.
- [ ] Deleted YNAB categories never appear regardless of config.
- [ ] The text input at the top fuzzy-filters category names; groups with zero matches disappear entirely; cursor resets to the first visible row on each filter change.
- [ ] Arrow keys navigate category rows only (group headers are not cursor-landable); Enter selects; Esc cancels.
- [ ] Categories with a null `group_name` appear under a single `Uncategorized` bucket.
- [ ] Running against an existing local SQLite DB (pre-migration) triggers a full re-sync on first run, populating correct Available balances for all categories.
- [ ] Verify a known category balance — "Steeple Chase Rent-1" should show +$1,541.00 for the current month after a fresh sync.
- [ ] `npm run build` passes with no TypeScript errors.
- [ ] `npm test` passes (55 tests across 9 suites).

## Test plan

- [ ] `npm run build`
- [ ] `npm test`
- [ ] Manual: `git pull`, then run the app — confirm the migration fires a full sync (balances populate, not all $0.00).
- [ ] Manual: press `c`; verify `Internal Master Category` is first, followed by user groups; verify `"Available (this month)"` label on each group header.
- [ ] Manual: confirm a known balance — "Steeple Chase Rent-1" should read +$1,541.00.
- [ ] Manual: type a partial name into the filter; verify empty groups collapse and cursor resets.
- [ ] Manual: toggle `include_hidden_categories: true` in config; verify hidden categories now appear in their groups.
- [ ] Regression: verify `y`, `n`, `s`, `x`, `m`, `u`, `q` keybinds still work in default mode.

https://claude.ai/code/session_01Ggg7CTnh128M6NRNpDUpLc