### PR TITLE
feat: receipt code dictionary — local lookup with LLM fallback (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@ Rip through YNAB unapproved transactions with single keystrokes.
 
 YNAB Blaster is a terminal CLI tool that lets you rapidly approve, recategorize, and skip YNAB transactions without leaving the keyboard. It syncs your budget locally into SQLite and provides a fast keyboard-driven interface for processing your unapproved queue.
 
-## Features (v0.1 — Foundation + Write Path + TUI)
+## Features (v0.2 — Receipt Code Dictionary)
 
 - **`ynab-blaster`** (no subcommand) — Syncs from YNAB and launches the full Ink terminal UI
 - **`init`** — Interactive first-time setup: enter your YNAB Personal Access Token, pick a budget, and write `config.yml`
 - **`sync`** — Fetches transactions, categories, and payees from YNAB into a local SQLite database with delta sync (only fetches changes after the first run)
 - **`status`** — Prints unapproved transaction count, inflight writes, and last sync time
 - **`retry-inflight`** — Force-retries any writes that didn't confirm in a previous session (crash recovery)
+- **`codes list <store>`** — Print all receipt-code dictionary entries for a store
+- **`codes edit`** — Open the full dictionary in `$EDITOR` as YAML; changes are re-imported atomically on save
 - **Write path with crash safety** — Every write (approve, recategorize, memo, flag) is journaled in `inflight_writes` before the API call. On failure, the local change is rolled back; on crash, the journal survives and can be replayed at startup or via `retry-inflight`
+- **Receipt code dictionary** — A local SQLite dictionary that maps `(store, code)` → description + category, built up as you process receipts. Keyed to the current transaction's payee so lookups are always store-scoped
 
 ### TUI Keybindings
 
@@ -21,6 +24,7 @@ YNAB Blaster is a terminal CLI tool that lets you rapidly approve, recategorize,
 |-----|--------|
 | `y` / Enter | Approve with suggested category |
 | `c` | Open category picker (fuzzy filter) |
+| `l` | Open receipt code lookup pane (scoped to current payee) |
 | `n` | Next transaction (no change) |
 | `s` | Skip |
 | `x` | Flag for split |
@@ -28,6 +32,19 @@ YNAB Blaster is a terminal CLI tool that lets you rapidly approve, recategorize,
 | `u` | Undo last action |
 | `q` | Quit |
 | `d` | Dismiss error banner |
+
+#### Receipt code lookup (`l`)
+
+Press `l` on any transaction to open the lookup pane:
+
+1. **Type the code** from your receipt (e.g. `PANTS LADIES`, `DEPT 42`)
+2. If there's an **exact match** in the dictionary → description + category are shown; press `a` to apply the saved category or `c` to pick a different one
+3. If there are **partial matches** → up to 5 similar codes are shown; navigate with ↑/↓ and press Enter to select
+4. If there's **no match** → you can either:
+   - `m` — type a description manually, then pick a category; saved to dictionary for next time
+   - `l` — ask Claude (requires `anthropic_api_key` in config); the LLM guess is shown as unconfirmed and must be accepted with `y` before saving
+
+If the transaction has no payee set, the pane will first prompt you to enter a store name for this lookup (not saved back to the transaction).
 
 ## Tech Stack
 
@@ -80,6 +97,30 @@ ynab-blaster status
 
 Prints the number of unapproved transactions, pending inflight writes, and the last sync timestamp.
 
+### View the receipt-code dictionary
+
+```bash
+ynab-blaster codes list "Ross"
+```
+
+Prints all saved codes for a store (case-insensitive). Example output:
+
+```
+Receipt codes for "ross" (3 entries):
+
+  DEPT 42              Home goods  [seen 2 times]
+  DEPT 9               Ladies shoes  [seen 1 time]
+  PANTS LADIES         Ladies pants / bottoms  [seen 5 times]
+```
+
+### Edit the receipt-code dictionary
+
+```bash
+ynab-blaster codes edit
+```
+
+Dumps the full dictionary to a YAML temp file and opens `$EDITOR` (falls back to `$VISUAL`, then `vi`). Edit freely — codes are grouped by store for readability. On save, the dictionary is re-imported atomically. If the YAML has a parse error, the DB is left untouched and the temp file path is printed so you can recover.
+
 ### Retry inflight writes
 
 ```bash
@@ -98,6 +139,10 @@ budget_id: your-budget-uuid
 db_path: ~/.local/share/ynab-blaster/ynab.db
 include_hidden_categories: false
 sort: date_desc  # date_desc | date_asc | account
+
+# Optional — only needed for the LLM receipt-code lookup fallback
+# Can also be set via the ANTHROPIC_API_KEY environment variable
+anthropic_api_key: sk-ant-...
 ```
 
 ## Architecture
@@ -118,6 +163,7 @@ src/
     sync.ts           # ynab-blaster sync
     status.ts         # ynab-blaster status
     retry-inflight.ts # ynab-blaster retry-inflight
+    codes.ts          # ynab-blaster codes list / codes edit
   db/
     client.ts         # Open SQLite database
     schema.ts         # Idempotent table + index creation
@@ -127,6 +173,8 @@ src/
     transactions.ts   # Transaction upsert + unapproved queue
     history.ts        # Payee→category history aggregation
     inflight.ts       # Insert, delete, and list inflight_writes rows
+    codes.ts          # Receipt-code dictionary CRUD (upsert, lookup, dump, replaceAll)
+  llm.ts              # Anthropic Haiku wrapper for receipt-code guesses
   tui/
     reducer.ts        # useReducer state shape, action types, pure reducer
     App.tsx           # Root component: loads queue, wires keybindings, mounts children
@@ -135,9 +183,12 @@ src/
     DefaultMode.tsx   # Main transaction view: payee history, suggestion, hints
     CategoryPicker.tsx # Fuzzy-filter category selector
     MemoEditor.tsx    # Inline memo editor
+    CodeLookup.tsx    # Receipt-code lookup pane (all phases: exact/partial/miss/LLM)
     ErrorBanner.tsx   # Dismissable error stack
     WriteStatus.tsx   # Bottom-right ✓/⏳/✗ write indicator
 tests/
+  codes.test.ts           # Receipt-code DB layer tests
+  llm.test.ts             # LLM wrapper tests (mocked Anthropic client)
   config.test.ts          # Config validation tests
   format.test.ts          # Milliunit formatter tests
   fuzzy.test.ts           # Fuzzy filter tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.90.0",
         "better-sqlite3": "^12.9.0",
         "commander": "^14.0.3",
         "ink": "^7.0.1",
@@ -44,6 +45,35 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1783,6 +1813,19 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
@@ -2718,6 +2761,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Joseph Loomis",
   "license": "ISC",
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.90.0",
     "better-sqlite3": "^12.9.0",
     "commander": "^14.0.3",
     "ink": "^7.0.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,26 @@ program
     await runRetryInflight();
   });
 
+const codesCmd = program
+  .command('codes')
+  .description('Manage the receipt-code dictionary');
+
+codesCmd
+  .command('list <store>')
+  .description('List all dictionary entries for a store')
+  .action(async (store: string) => {
+    const { runCodesList } = await import('./commands/codes.js');
+    runCodesList(store);
+  });
+
+codesCmd
+  .command('edit')
+  .description('Open the full dictionary in $EDITOR (YAML round-trip)')
+  .action(async () => {
+    const { runCodesEdit } = await import('./commands/codes.js');
+    runCodesEdit();
+  });
+
 // Default command (no subcommand) — runs the TUI blaster.
 program
   .command('run', { isDefault: true, hidden: true })

--- a/src/commands/codes.ts
+++ b/src/commands/codes.ts
@@ -1,0 +1,149 @@
+import { spawnSync } from 'child_process';
+import { mkdtempSync, writeFileSync, readFileSync, unlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { dump, load } from 'js-yaml';
+import { loadConfig } from '../config.js';
+import { openDatabase } from '../db/client.js';
+import { applySchema } from '../db/schema.js';
+import { dumpForStore, dumpAll, replaceAll, type ReceiptCodeRow } from '../db/codes.js';
+
+// `ynab-blaster codes list <store>` — print all dictionary entries for a store.
+export function runCodesList(store: string): void {
+  const config = loadConfig();
+  const db = openDatabase(config.db_path);
+  applySchema(db);
+
+  const rows = dumpForStore(db, store);
+  db.close();
+
+  if (rows.length === 0) {
+    console.log(`No codes found for store "${store}".`);
+    return;
+  }
+
+  console.log(`Receipt codes for "${store}" (${rows.length} entries):\n`);
+  for (const row of rows) {
+    const desc = row.description ?? '(no description)';
+    const seen = row.times_seen === 1 ? '1 time' : `${row.times_seen} times`;
+    console.log(`  ${row.code.padEnd(20)} ${desc}  [seen ${seen}]`);
+  }
+}
+
+// YAML format used for export/import — grouped by store for human readability.
+interface YamlStore {
+  [code: string]: {
+    description: string | null;
+    suggested_category_id: string | null;
+    times_seen: number;
+    first_seen: string;
+    last_seen: string;
+  };
+}
+
+interface YamlDump {
+  [storeName: string]: YamlStore;
+}
+
+// Convert DB rows to the grouped YAML structure.
+function rowsToYaml(rows: ReceiptCodeRow[]): YamlDump {
+  const result: YamlDump = {};
+  for (const row of rows) {
+    if (!result[row.store_name]) result[row.store_name] = {};
+    result[row.store_name][row.code] = {
+      description: row.description,
+      suggested_category_id: row.suggested_category_id,
+      times_seen: row.times_seen,
+      first_seen: row.first_seen,
+      last_seen: row.last_seen,
+    };
+  }
+  return result;
+}
+
+// Convert the grouped YAML structure back to flat DB rows.
+function yamlToRows(parsed: YamlDump): ReceiptCodeRow[] {
+  const rows: ReceiptCodeRow[] = [];
+  for (const [storeName, codes] of Object.entries(parsed)) {
+    for (const [code, meta] of Object.entries(codes)) {
+      rows.push({
+        store_name: storeName,
+        code,
+        description: meta.description ?? null,
+        suggested_category_id: meta.suggested_category_id ?? null,
+        times_seen: typeof meta.times_seen === 'number' ? meta.times_seen : 1,
+        first_seen: meta.first_seen ?? new Date().toISOString(),
+        last_seen: meta.last_seen ?? new Date().toISOString(),
+      });
+    }
+  }
+  return rows;
+}
+
+// `ynab-blaster codes edit` — dump dictionary to YAML, open in $EDITOR, re-import on save.
+// On YAML parse failure the DB is left untouched; the temp file path is printed for recovery.
+export function runCodesEdit(): void {
+  const config = loadConfig();
+  const db = openDatabase(config.db_path);
+  applySchema(db);
+
+  const rows = dumpAll(db);
+  const yamlContent = dump(rowsToYaml(rows), { lineWidth: 120 });
+
+  // Write to a named temp file so the editor can show a meaningful filename.
+  const dir = mkdtempSync(join(tmpdir(), 'ynab-blaster-codes-'));
+  const tmpFile = join(dir, 'receipt-codes.yml');
+  writeFileSync(tmpFile, yamlContent, 'utf8');
+
+  const editor = process.env.EDITOR ?? process.env.VISUAL ?? 'vi';
+
+  // spawn with stdio: 'inherit' so the editor gets direct terminal access.
+  const result = spawnSync(editor, [tmpFile], { stdio: 'inherit' });
+
+  if (result.error) {
+    console.error(`Failed to launch editor "${editor}": ${result.error.message}`);
+    console.error(`Your dictionary is unchanged. Temp file: ${tmpFile}`);
+    db.close();
+    return;
+  }
+
+  // Parse the edited YAML and re-import only if parse succeeds.
+  let edited: string;
+  try {
+    edited = readFileSync(tmpFile, 'utf8');
+  } catch {
+    console.error('Could not read temp file after editor closed. Dictionary unchanged.');
+    db.close();
+    return;
+  }
+
+  let parsed: YamlDump;
+  try {
+    parsed = (load(edited) ?? {}) as YamlDump;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`YAML parse error — dictionary unchanged.\n${msg}`);
+    console.error(`Temp file preserved for recovery: ${tmpFile}`);
+    db.close();
+    return;
+  }
+
+  let newRows: ReceiptCodeRow[];
+  try {
+    newRows = yamlToRows(parsed);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Could not interpret YAML structure — dictionary unchanged.\n${msg}`);
+    console.error(`Temp file preserved for recovery: ${tmpFile}`);
+    db.close();
+    return;
+  }
+
+  replaceAll(db, newRows);
+  db.close();
+
+  // Clean up temp file only on success.
+  try { unlinkSync(tmpFile); } catch { /* ignore */ }
+
+  console.log(`Dictionary updated. ${newRows.length} codes across ${Object.keys(parsed).length} store(s).`);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,8 @@ export interface Config {
   db_path: string;
   include_hidden_categories: boolean;
   sort: SortOrder;
+  // Optional — required only for the LLM receipt-code lookup fallback.
+  anthropic_api_key: string | undefined;
 }
 
 const VALID_SORTS: SortOrder[] = ['date_desc', 'date_asc', 'account'];
@@ -31,12 +33,19 @@ export function parseConfig(raw: Record<string, unknown>): Config {
   if (!VALID_SORTS.includes(sort)) {
     throw new Error(`Config error: sort must be one of ${VALID_SORTS.join(', ')}`);
   }
+  // anthropic_api_key: prefer YAML, fall back to env var, allow absent.
+  const anthropic_api_key =
+    (typeof raw.anthropic_api_key === 'string' && raw.anthropic_api_key)
+      ? raw.anthropic_api_key
+      : (process.env.ANTHROPIC_API_KEY ?? undefined);
+
   return {
     personal_access_token: raw.personal_access_token,
     budget_id: raw.budget_id,
     db_path: (raw.db_path as string).replace('~', homedir()),
     include_hidden_categories: (raw.include_hidden_categories as boolean) ?? false,
     sort,
+    anthropic_api_key,
   };
 }
 

--- a/src/db/codes.ts
+++ b/src/db/codes.ts
@@ -1,0 +1,129 @@
+import type Database from 'better-sqlite3';
+
+export interface ReceiptCodeRow {
+  store_name: string;
+  code: string;
+  description: string | null;
+  suggested_category_id: string | null;
+  times_seen: number;
+  first_seen: string;
+  last_seen: string;
+}
+
+// Normalise store names so "ROSS DRESS FOR LESS" and "Ross" map to the same key.
+const normaliseStore = (name: string): string => name.trim().toLowerCase();
+
+// Normalise codes for consistent matching (trim whitespace, uppercase).
+const normaliseCode = (code: string): string => code.trim().toUpperCase();
+
+// Insert or update a receipt code. Increments times_seen on conflict.
+export function upsertReceiptCode(
+  db: Database.Database,
+  storeName: string,
+  code: string,
+  description: string | null,
+  suggestedCategoryId: string | null
+): void {
+  const now = new Date().toISOString();
+  const store = normaliseStore(storeName);
+  const normCode = normaliseCode(code);
+
+  db.prepare<{
+    store_name: string;
+    code: string;
+    description: string | null;
+    suggested_category_id: string | null;
+    now: string;
+  }>(
+    `INSERT INTO receipt_codes (store_name, code, description, suggested_category_id, times_seen, first_seen, last_seen)
+     VALUES (@store_name, @code, @description, @suggested_category_id, 1, @now, @now)
+     ON CONFLICT(store_name, code) DO UPDATE SET
+       description = excluded.description,
+       suggested_category_id = excluded.suggested_category_id,
+       times_seen = times_seen + 1,
+       last_seen = excluded.last_seen`
+  ).run({ store_name: store, code: normCode, description, suggested_category_id: suggestedCategoryId, now });
+}
+
+// Look up an exact (store, code) pair. Returns null if not found.
+export function exactLookup(
+  db: Database.Database,
+  storeName: string,
+  code: string
+): ReceiptCodeRow | null {
+  const store = normaliseStore(storeName);
+  const normCode = normaliseCode(code);
+  const row = db
+    .prepare<{ store_name: string; code: string }>(
+      `SELECT * FROM receipt_codes WHERE store_name = @store_name AND code = @code`
+    )
+    .get({ store_name: store, code: normCode }) as ReceiptCodeRow | undefined;
+  return row ?? null;
+}
+
+// Find up to `limit` codes for a store whose code contains the query as a substring.
+// Returns [] when no partial matches are found.
+export function partialLookup(
+  db: Database.Database,
+  storeName: string,
+  query: string,
+  limit = 5
+): ReceiptCodeRow[] {
+  const store = normaliseStore(storeName);
+  const normQuery = normaliseCode(query);
+  return db
+    .prepare<{ store_name: string; query: string; limit: number }>(
+      `SELECT * FROM receipt_codes
+       WHERE store_name = @store_name AND code LIKE '%' || @query || '%'
+       ORDER BY times_seen DESC, code ASC
+       LIMIT @limit`
+    )
+    .all({ store_name: store, query: normQuery, limit }) as ReceiptCodeRow[];
+}
+
+// Return all receipt codes for a store, ordered by code.
+export function dumpForStore(
+  db: Database.Database,
+  storeName: string
+): ReceiptCodeRow[] {
+  const store = normaliseStore(storeName);
+  return db
+    .prepare<{ store_name: string }>(
+      `SELECT * FROM receipt_codes WHERE store_name = @store_name ORDER BY code ASC`
+    )
+    .all({ store_name: store }) as ReceiptCodeRow[];
+}
+
+// Return all receipt codes across all stores, grouped by store name.
+export function dumpAll(db: Database.Database): ReceiptCodeRow[] {
+  return db
+    .prepare(`SELECT * FROM receipt_codes ORDER BY store_name ASC, code ASC`)
+    .all() as ReceiptCodeRow[];
+}
+
+// Delete all receipt codes for a store (used during YAML re-import).
+export function deleteForStore(db: Database.Database, storeName: string): void {
+  const store = normaliseStore(storeName);
+  db.prepare<{ store_name: string }>(
+    `DELETE FROM receipt_codes WHERE store_name = @store_name`
+  ).run({ store_name: store });
+}
+
+// Replace ALL receipt codes in one atomic transaction (used by `codes edit` YAML re-import).
+export function replaceAll(db: Database.Database, rows: ReceiptCodeRow[]): void {
+  const replace = db.transaction((entries: ReceiptCodeRow[]) => {
+    db.prepare(`DELETE FROM receipt_codes`).run();
+    const insert = db.prepare<ReceiptCodeRow>(
+      `INSERT INTO receipt_codes (store_name, code, description, suggested_category_id, times_seen, first_seen, last_seen)
+       VALUES (@store_name, @code, @description, @suggested_category_id, @times_seen, @first_seen, @last_seen)`
+    );
+    for (const row of entries) {
+      insert.run({
+        ...row,
+        store_name: normaliseStore(row.store_name),
+        code: normaliseCode(row.code),
+      });
+    }
+  });
+  replace(rows);
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -57,6 +57,18 @@ export function applySchema(db: Database.Database): void {
       payload TEXT NOT NULL,
       created_at TEXT NOT NULL
     );
+
+    CREATE TABLE IF NOT EXISTS receipt_codes (
+      store_name TEXT NOT NULL,
+      code TEXT NOT NULL,
+      description TEXT,
+      suggested_category_id TEXT,
+      times_seen INTEGER NOT NULL DEFAULT 1,
+      first_seen TEXT NOT NULL,
+      last_seen TEXT NOT NULL,
+      PRIMARY KEY (store_name, code)
+    );
+    CREATE INDEX IF NOT EXISTS idx_codes_store ON receipt_codes(store_name);
   `);
 
   // Migrate pre-existing DBs that were created before the `balance` column existed.

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1,0 +1,78 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+export interface LlmGuess {
+  description: string;
+  // Confidence is optional; the model may decline to estimate.
+  confidence?: 'high' | 'medium' | 'low';
+}
+
+// Build a single Anthropic client lazily — callers must supply the API key.
+function buildClient(apiKey: string): Anthropic {
+  return new Anthropic({ apiKey });
+}
+
+// Ask Claude Haiku for a plain-English description of an unknown receipt code.
+// Returns null if the model cannot make a reasonable guess.
+// The caller is responsible for showing this as unconfirmed and requiring
+// explicit user confirmation before saving to the dictionary.
+export async function guessReceiptCode(
+  apiKey: string,
+  storeName: string,
+  code: string
+): Promise<LlmGuess | null> {
+  const client = buildClient(apiKey);
+
+  // Haiku 4.5 — fast and cheap for a single-sentence classification task.
+  const response = await client.messages.create({
+    model: 'claude-haiku-4-5',
+    max_tokens: 256,
+    messages: [
+      {
+        role: 'user',
+        content: buildPrompt(storeName, code),
+      },
+    ],
+  });
+
+  const textBlock = response.content.find((b) => b.type === 'text');
+  if (!textBlock || textBlock.type !== 'text') return null;
+
+  return parseResponse(textBlock.text);
+}
+
+// Prompt engineered to elicit a short, structured plain-text response.
+function buildPrompt(storeName: string, code: string): string {
+  return `You are helping a user understand a cryptic code or abbreviation printed on a retail receipt.
+
+Store: ${storeName}
+Receipt code: ${code}
+
+In 1-2 sentences, describe what this code most likely refers to (e.g. product category, department, item type). If you cannot make a reasonable guess, say "Unknown".
+
+Then on a new line, rate your confidence: HIGH, MEDIUM, or LOW.
+
+Example output:
+Ladies' pants or trousers — clothing department item.
+MEDIUM`;
+}
+
+// Extract description and confidence from the model's free-text response.
+function parseResponse(raw: string): LlmGuess | null {
+  const lines = raw.trim().split('\n').filter((l) => l.trim().length > 0);
+  if (lines.length === 0) return null;
+
+  // Last line is the confidence rating if it matches known values.
+  const lastLine = lines[lines.length - 1].trim().toUpperCase();
+  let confidence: LlmGuess['confidence'] | undefined;
+  let descriptionLines = lines;
+
+  if (lastLine === 'HIGH' || lastLine === 'MEDIUM' || lastLine === 'LOW') {
+    confidence = lastLine.toLowerCase() as LlmGuess['confidence'];
+    descriptionLines = lines.slice(0, -1);
+  }
+
+  const description = descriptionLines.join(' ').trim();
+  if (!description || description.toUpperCase() === 'UNKNOWN') return null;
+
+  return { description, confidence };
+}

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -9,6 +9,7 @@ import { Footer } from './Footer.js';
 import { DefaultMode } from './DefaultMode.js';
 import { CategoryPicker } from './CategoryPicker.js';
 import { MemoEditor } from './MemoEditor.js';
+import { CodeLookup } from './CodeLookup.js';
 import { ErrorBanner } from './ErrorBanner.js';
 import { WriteStatus } from './WriteStatus.js';
 import { WriteManager } from '../write-manager.js';
@@ -74,6 +75,7 @@ export function App({ db, api, config }: Props) {
       fireWrite(() => manager.approve(currentTx.id, suggestedCategory.id));
     }
     if (input === 'c') dispatch({ type: 'SET_MODE', mode: 'picker' });
+    if (input === 'l') dispatch({ type: 'SET_MODE', mode: 'lookup' });
     if (input === 'n') dispatch({ type: 'NEXT' });
     if (input === 's') dispatch({ type: 'NEXT' });
     if (input === 'x') fireWrite(() => manager.flagForSplit(currentTx.id));
@@ -91,6 +93,17 @@ export function App({ db, api, config }: Props) {
     if (!currentTx) return;
     dispatch({ type: 'SET_MODE', mode: 'default' });
     fireWrite(() => manager.editMemo(currentTx.id, memo));
+  };
+
+  // When the user applies a category found via the code lookup pane, treat it
+  // as a normal category-select approve (same as picking from CategoryPicker).
+  const handleLookupApplyCategory = (categoryId: string, _categoryName: string) => {
+    if (!currentTx) {
+      dispatch({ type: 'SET_MODE', mode: 'default' });
+      return;
+    }
+    dispatch({ type: 'SET_MODE', mode: 'default' });
+    fireWrite(() => manager.approve(currentTx.id, categoryId));
   };
 
   if (state.queue.length === 0) {
@@ -133,6 +146,17 @@ export function App({ db, api, config }: Props) {
           initialMemo={currentTx.memo ?? ''}
           onSubmit={handleMemoSubmit}
           onCancel={() => dispatch({ type: 'SET_MODE', mode: 'default' })}
+        />
+      )}
+
+      {state.mode === 'lookup' && (
+        <CodeLookup
+          db={db}
+          payeeName={currentTx.payee_name ?? null}
+          categoryGroups={categoryGroups}
+          anthropicApiKey={config.anthropic_api_key}
+          onApplyCategory={handleLookupApplyCategory}
+          onClose={() => dispatch({ type: 'SET_MODE', mode: 'default' })}
         />
       )}
 

--- a/src/tui/CodeLookup.tsx
+++ b/src/tui/CodeLookup.tsx
@@ -1,0 +1,338 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import TextInput from 'ink-text-input';
+import type Database from 'better-sqlite3';
+import {
+  exactLookup,
+  partialLookup,
+  upsertReceiptCode,
+  type ReceiptCodeRow,
+} from '../db/codes.js';
+import { CategoryPicker } from './CategoryPicker.js';
+import type { CategoryGroup } from '../db/categories.js';
+import { guessReceiptCode, type LlmGuess } from '../llm.js';
+
+// ---------- Phase type ----------
+
+type Phase =
+  | 'store-prompt'    // no payee on tx — ask user for store name
+  | 'code-input'      // user types the receipt code to look up
+  | 'exact-match'     // single exact result found
+  | 'partial-match'   // list of fuzzy results shown
+  | 'miss'            // no match — choose: manual entry or ask LLM
+  | 'manual-desc'     // user types description for new entry
+  | 'manual-category' // user picks category via CategoryPicker
+  | 'llm-loading'     // waiting for LLM response
+  | 'llm-confirm'     // LLM returned a guess — show and ask user to confirm or discard
+  | 'llm-category';   // user picks category after accepting LLM description
+
+// ---------- Props ----------
+
+interface Props {
+  db: Database.Database;
+  // The payee name from the current transaction; null when no payee is set.
+  payeeName: string | null;
+  categoryGroups: CategoryGroup[];
+  // Optional API key; when absent the LLM fallback is unavailable.
+  anthropicApiKey: string | undefined;
+  // Called when the user chooses to apply a looked-up code's category to the current tx.
+  onApplyCategory: (categoryId: string, categoryName: string) => void;
+  onClose: () => void;
+}
+
+// ---------- Component ----------
+
+export function CodeLookup({
+  db,
+  payeeName,
+  categoryGroups,
+  anthropicApiKey,
+  onApplyCategory,
+  onClose,
+}: Props) {
+  // Resolved store name (from payee or manual prompt).
+  const [storeName, setStoreName] = useState<string>(payeeName ?? '');
+  const [storeInput, setStoreInput] = useState('');
+
+  const [codeInput, setCodeInput] = useState('');
+
+  // Current phase of the lookup flow.
+  const [phase, setPhase] = useState<Phase>(payeeName ? 'code-input' : 'store-prompt');
+
+  // Results state.
+  const [exactRow, setExactRow] = useState<ReceiptCodeRow | null>(null);
+  const [partialRows, setPartialRows] = useState<ReceiptCodeRow[]>([]);
+  const [partialCursor, setPartialCursor] = useState(0);
+
+  // Manual-entry state.
+  const [manualDesc, setManualDesc] = useState('');
+  // Category selected during manual or LLM confirm flow.
+  const [pendingCategoryId, setPendingCategoryId] = useState<string | null>(null);
+  const [pendingCategoryName, setPendingCategoryName] = useState<string | null>(null);
+
+  // LLM state.
+  const [llmGuess, setLlmGuess] = useState<LlmGuess | null>(null);
+  const [llmError, setLlmError] = useState<string | null>(null);
+
+  // ---------- useInput: handle navigation keys at each phase ----------
+
+  useInput((input, key) => {
+    // Escape always closes the pane and returns to default mode.
+    if (key.escape) {
+      onClose();
+      return;
+    }
+
+    switch (phase) {
+      case 'store-prompt':
+        // TextInput handles typing; Enter handled via onSubmit prop below.
+        break;
+
+      case 'code-input':
+        // TextInput handles typing; Enter via onSubmit.
+        break;
+
+      case 'exact-match':
+        if (input === 'a' && exactRow?.suggested_category_id) {
+          // Apply saved category directly.
+          const cat = categoryGroups.flatMap((g) => g.categories).find(
+            (c) => c.id === exactRow.suggested_category_id
+          );
+          if (cat) {
+            upsertReceiptCode(db, storeName, exactRow.code, exactRow.description, cat.id);
+            onApplyCategory(cat.id, cat.name);
+          } else {
+            onClose();
+          }
+        }
+        if (input === 'c') {
+          // Apply with category picker (category might not have been saved previously).
+          setPhase('manual-category');
+        }
+        // Any other key closes.
+        if (input !== 'a' && input !== 'c' && !key.escape) {
+          onClose();
+        }
+        break;
+
+      case 'partial-match':
+        if (key.upArrow) setPartialCursor((c) => Math.max(0, c - 1));
+        if (key.downArrow) setPartialCursor((c) => Math.min(partialRows.length - 1, c + 1));
+        if (key.return) {
+          const row = partialRows[partialCursor];
+          if (row) {
+            setExactRow(row);
+            setPhase('exact-match');
+          }
+        }
+        break;
+
+      case 'miss':
+        if (input === 'm') setPhase('manual-desc');
+        if (input === 'l' && anthropicApiKey) {
+          setPhase('llm-loading');
+          triggerLlmGuess();
+        }
+        break;
+
+      case 'manual-desc':
+        // TextInput handles typing; Enter via onSubmit.
+        break;
+
+      case 'llm-loading':
+        // Nothing to do; waiting for async result.
+        break;
+
+      case 'llm-confirm':
+        if (input === 'y') {
+          // Accept guess description; proceed to category picker.
+          setPhase('llm-category');
+        }
+        if (input === 'n') {
+          // Discard LLM result; fall back to manual entry.
+          setPhase('manual-desc');
+        }
+        break;
+
+      case 'manual-category':
+      case 'llm-category':
+        // CategoryPicker handles input via its own useInput.
+        break;
+    }
+  });
+
+  // ---------- Async helpers ----------
+
+  function triggerLlmGuess() {
+    if (!anthropicApiKey) return;
+    guessReceiptCode(anthropicApiKey, storeName, codeInput)
+      .then((guess) => {
+        setLlmGuess(guess);
+        setPhase('llm-confirm');
+      })
+      .catch((err: unknown) => {
+        setLlmError(err instanceof Error ? err.message : String(err));
+        setPhase('miss');
+      });
+  }
+
+  // ---------- Submit handlers ----------
+
+  function handleStoreSubmit(value: string) {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    setStoreName(trimmed);
+    setPhase('code-input');
+  }
+
+  function handleCodeSubmit(value: string) {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+
+    const exact = exactLookup(db, storeName, trimmed);
+    if (exact) {
+      setExactRow(exact);
+      upsertReceiptCode(db, storeName, trimmed, exact.description, exact.suggested_category_id);
+      setPhase('exact-match');
+      return;
+    }
+
+    const partial = partialLookup(db, storeName, trimmed, 5);
+    if (partial.length > 0) {
+      setPartialRows(partial);
+      setPartialCursor(0);
+      setPhase('partial-match');
+      return;
+    }
+
+    setPhase('miss');
+  }
+
+  function handleManualDescSubmit(value: string) {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    setManualDesc(trimmed);
+    setPhase('manual-category');
+  }
+
+  function handleCategorySelect(categoryId: string, categoryName: string) {
+    // Save to the dictionary.
+    upsertReceiptCode(db, storeName, codeInput, manualDesc || llmGuess?.description || null, categoryId);
+    setPendingCategoryId(categoryId);
+    setPendingCategoryName(categoryName);
+    // Apply the category to the transaction and close.
+    onApplyCategory(categoryId, categoryName);
+  }
+
+  // ---------- Render ----------
+
+  return (
+    <Box flexDirection="column">
+      <Text bold color="cyan">── Receipt Code Lookup (Esc to close) ──</Text>
+
+      {phase === 'store-prompt' && (
+        <Box flexDirection="column">
+          <Text>No payee on this transaction. Enter a store name for this lookup:</Text>
+          <TextInput
+            value={storeInput}
+            onChange={setStoreInput}
+            onSubmit={handleStoreSubmit}
+            placeholder="e.g. Ross"
+          />
+        </Box>
+      )}
+
+      {phase === 'code-input' && (
+        <Box flexDirection="column">
+          <Text>Store: <Text bold>{storeName}</Text></Text>
+          <Text>Enter the code from your receipt:</Text>
+          <TextInput
+            value={codeInput}
+            onChange={setCodeInput}
+            onSubmit={handleCodeSubmit}
+            placeholder="e.g. PANTS LADIES"
+          />
+        </Box>
+      )}
+
+      {phase === 'exact-match' && exactRow && (
+        <Box flexDirection="column">
+          <Text color="green">✓ Match found for <Text bold>{exactRow.code}</Text></Text>
+          <Text>  {exactRow.description ?? '(no description saved)'}</Text>
+          {exactRow.suggested_category_id && (
+            <Text dimColor>  Seen {exactRow.times_seen}× — last used category saved</Text>
+          )}
+          <Text dimColor>
+            [a] apply saved category  [c] pick category  [Esc] close
+          </Text>
+        </Box>
+      )}
+
+      {phase === 'partial-match' && (
+        <Box flexDirection="column">
+          <Text color="yellow">Similar codes for <Text bold>{storeName}</Text>:</Text>
+          {partialRows.map((row, i) => (
+            <Text key={row.code} inverse={i === partialCursor}>
+              {'  '}{row.code.padEnd(22)}{row.description ?? ''}
+            </Text>
+          ))}
+          <Text dimColor>↑/↓ to select, Enter to view, Esc to close</Text>
+        </Box>
+      )}
+
+      {phase === 'miss' && (
+        <Box flexDirection="column">
+          <Text color="yellow">No match for <Text bold>{codeInput}</Text> at <Text bold>{storeName}</Text>.</Text>
+          {llmError && <Text color="red">LLM error: {llmError}</Text>}
+          <Text dimColor>
+            [m] enter description manually
+            {anthropicApiKey ? '  [l] ask Claude for a guess' : '  (set anthropic_api_key to enable LLM)'}
+            {'  '}[Esc] close
+          </Text>
+        </Box>
+      )}
+
+      {phase === 'manual-desc' && (
+        <Box flexDirection="column">
+          <Text>Enter a description for <Text bold>{codeInput}</Text>:</Text>
+          <TextInput
+            value={manualDesc}
+            onChange={setManualDesc}
+            onSubmit={handleManualDescSubmit}
+            placeholder="e.g. Ladies pants / bottoms"
+          />
+        </Box>
+      )}
+
+      {phase === 'llm-loading' && (
+        <Box flexDirection="column">
+          <Text>Asking Claude about <Text bold>{codeInput}</Text>…</Text>
+        </Box>
+      )}
+
+      {phase === 'llm-confirm' && (
+        <Box flexDirection="column">
+          <Text color="cyan">Claude's guess for <Text bold>{codeInput}</Text>:</Text>
+          <Text>  {llmGuess?.description ?? '(no guess returned)'}</Text>
+          {llmGuess?.confidence && (
+            <Text dimColor>  Confidence: {llmGuess.confidence}</Text>
+          )}
+          <Text dimColor>[y] accept and pick category  [n] enter manually instead  [Esc] close</Text>
+        </Box>
+      )}
+
+      {(phase === 'manual-category' || phase === 'llm-category') && (
+        <Box flexDirection="column">
+          <Text dimColor>
+            Saving: <Text bold>{codeInput}</Text> → {manualDesc || llmGuess?.description || ''}
+          </Text>
+          <CategoryPicker
+            groups={categoryGroups}
+            onSelect={handleCategorySelect}
+            onCancel={onClose}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/tui/reducer.ts
+++ b/src/tui/reducer.ts
@@ -1,6 +1,6 @@
 import type { TransactionRow } from '../db/transactions.js';
 
-export type Mode = 'default' | 'picker' | 'memo';
+export type Mode = 'default' | 'picker' | 'memo' | 'lookup';
 export type WriteStatus = 'idle' | 'saving' | 'saved' | 'failed';
 
 export interface AppState {

--- a/tests/codes.test.ts
+++ b/tests/codes.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { openDatabase } from '../src/db/client.js';
+import { applySchema } from '../src/db/schema.js';
+import {
+  upsertReceiptCode,
+  exactLookup,
+  partialLookup,
+  dumpForStore,
+  dumpAll,
+  replaceAll,
+  type ReceiptCodeRow,
+} from '../src/db/codes.js';
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = openDatabase(':memory:');
+  applySchema(db);
+});
+
+describe('upsertReceiptCode', () => {
+  it('inserts a new code and returns it via exactLookup', () => {
+    upsertReceiptCode(db, 'Ross', 'PANTS LADIES', 'Ladies pants / bottoms', null);
+    const row = exactLookup(db, 'Ross', 'PANTS LADIES');
+    expect(row).not.toBeNull();
+    expect(row?.description).toBe('Ladies pants / bottoms');
+    expect(row?.times_seen).toBe(1);
+  });
+
+  it('normalises store name to lowercase', () => {
+    upsertReceiptCode(db, 'ROSS DRESS FOR LESS', 'DEPT 42', 'Home goods', null);
+    // Lookup with a different casing of the same store should still find it.
+    const row = exactLookup(db, 'ross dress for less', 'DEPT 42');
+    expect(row).not.toBeNull();
+  });
+
+  it('normalises code to uppercase', () => {
+    upsertReceiptCode(db, 'Target', 'dept 42', 'Home goods', null);
+    const row = exactLookup(db, 'Target', 'DEPT 42');
+    expect(row).not.toBeNull();
+  });
+
+  it('increments times_seen and updates description on conflict', () => {
+    upsertReceiptCode(db, 'TJ Maxx', '284070725', 'Old description', null);
+    upsertReceiptCode(db, 'TJ Maxx', '284070725', 'Updated description', 'cat-1');
+    const row = exactLookup(db, 'TJ Maxx', '284070725');
+    expect(row?.times_seen).toBe(2);
+    expect(row?.description).toBe('Updated description');
+    expect(row?.suggested_category_id).toBe('cat-1');
+  });
+
+  it('stores suggested_category_id', () => {
+    upsertReceiptCode(db, 'Burlington', 'DEPT 10', 'Clothing', 'cat-abc');
+    const row = exactLookup(db, 'Burlington', 'DEPT 10');
+    expect(row?.suggested_category_id).toBe('cat-abc');
+  });
+});
+
+describe('exactLookup', () => {
+  it('returns null when code does not exist', () => {
+    const row = exactLookup(db, 'Target', 'NONEXISTENT');
+    expect(row).toBeNull();
+  });
+
+  it('is case-insensitive for both store and code', () => {
+    upsertReceiptCode(db, 'target', 'food & bev', 'Food and beverages', null);
+    const row = exactLookup(db, 'TARGET', 'FOOD & BEV');
+    expect(row).not.toBeNull();
+  });
+});
+
+describe('partialLookup', () => {
+  beforeEach(() => {
+    upsertReceiptCode(db, 'Ross', 'DEPT 1', 'Department 1', null);
+    upsertReceiptCode(db, 'Ross', 'DEPT 2', 'Department 2', null);
+    upsertReceiptCode(db, 'Ross', 'DEPT 10', 'Department 10', null);
+    upsertReceiptCode(db, 'Ross', 'PANTS LADIES', 'Ladies pants', null);
+    upsertReceiptCode(db, 'TJ Maxx', 'DEPT 3', 'Different store dept', null);
+  });
+
+  it('returns codes matching the query fragment for the given store', () => {
+    const results = partialLookup(db, 'Ross', 'DEPT');
+    expect(results).toHaveLength(3);
+    expect(results.every((r) => r.store_name === 'ross')).toBe(true);
+  });
+
+  it('does not return codes from other stores', () => {
+    const results = partialLookup(db, 'Ross', 'DEPT');
+    expect(results.some((r) => r.store_name === 'tj maxx')).toBe(false);
+  });
+
+  it('returns empty array when no partial match found', () => {
+    const results = partialLookup(db, 'Ross', 'ZZZZZ');
+    expect(results).toHaveLength(0);
+  });
+
+  it('respects the limit parameter', () => {
+    const results = partialLookup(db, 'Ross', 'DEPT', 2);
+    expect(results).toHaveLength(2);
+  });
+});
+
+describe('dumpForStore', () => {
+  it('returns all codes for a store ordered by code', () => {
+    upsertReceiptCode(db, 'Target', 'ZEBRA', 'Z item', null);
+    upsertReceiptCode(db, 'Target', 'APPLE', 'A item', null);
+    upsertReceiptCode(db, 'Ross', 'OTHER', 'Other store', null);
+
+    const results = dumpForStore(db, 'Target');
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.code)).toEqual(['APPLE', 'ZEBRA']);
+  });
+
+  it('returns empty array for unknown store', () => {
+    expect(dumpForStore(db, 'Unknown Store')).toHaveLength(0);
+  });
+});
+
+describe('dumpAll', () => {
+  it('returns codes from all stores ordered by store then code', () => {
+    upsertReceiptCode(db, 'Ross', 'CODE-B', 'B', null);
+    upsertReceiptCode(db, 'Target', 'CODE-A', 'A', null);
+    upsertReceiptCode(db, 'Ross', 'CODE-A', 'A', null);
+
+    const results = dumpAll(db);
+    expect(results[0].store_name).toBe('ross');
+    expect(results[0].code).toBe('CODE-A');
+    expect(results[1].store_name).toBe('ross');
+    expect(results[1].code).toBe('CODE-B');
+    expect(results[2].store_name).toBe('target');
+  });
+});
+
+describe('replaceAll', () => {
+  it('replaces all existing codes with the new set atomically', () => {
+    upsertReceiptCode(db, 'Old Store', 'OLD-1', 'Old', null);
+
+    const newRows: ReceiptCodeRow[] = [
+      {
+        store_name: 'new store',
+        code: 'NEW-1',
+        description: 'New item',
+        suggested_category_id: null,
+        times_seen: 3,
+        first_seen: '2025-01-01T00:00:00.000Z',
+        last_seen: '2025-01-02T00:00:00.000Z',
+      },
+    ];
+
+    replaceAll(db, newRows);
+
+    // Old data gone.
+    expect(exactLookup(db, 'Old Store', 'OLD-1')).toBeNull();
+    // New data present.
+    const row = exactLookup(db, 'new store', 'NEW-1');
+    expect(row?.description).toBe('New item');
+    expect(row?.times_seen).toBe(3);
+  });
+
+  it('normalises store and code during replaceAll', () => {
+    const newRows: ReceiptCodeRow[] = [
+      {
+        store_name: 'UPPERCASE STORE',
+        code: 'lowercase-code',
+        description: 'Test',
+        suggested_category_id: null,
+        times_seen: 1,
+        first_seen: '2025-01-01T00:00:00.000Z',
+        last_seen: '2025-01-01T00:00:00.000Z',
+      },
+    ];
+    replaceAll(db, newRows);
+    // Should be findable via normalised form.
+    expect(exactLookup(db, 'uppercase store', 'LOWERCASE-CODE')).not.toBeNull();
+  });
+});

--- a/tests/llm.test.ts
+++ b/tests/llm.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Shared mock for messages.create — declared at module scope so tests can access it.
+const mockCreate = vi.fn();
+
+// Mock the Anthropic SDK before importing the module under test.
+// The default export must be a class (constructor), not an arrow function.
+vi.mock('@anthropic-ai/sdk', () => {
+  return {
+    default: class MockAnthropic {
+      messages = { create: mockCreate };
+    },
+  };
+});
+
+// Import after mock is registered.
+import { guessReceiptCode } from '../src/llm.js';
+
+beforeEach(() => {
+  mockCreate.mockReset();
+});
+
+describe('guessReceiptCode', () => {
+  it('returns description and confidence when model gives a clean response', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [
+        {
+          type: 'text',
+          text: "Ladies' pants or trousers — clothing department item.\nMEDIUM",
+        },
+      ],
+    });
+
+    const result = await guessReceiptCode('fake-key', 'Ross', 'PANTS LADIES');
+    expect(result).not.toBeNull();
+    expect(result?.description).toBe("Ladies' pants or trousers — clothing department item.");
+    expect(result?.confidence).toBe('medium');
+  });
+
+  it('returns description without confidence when model omits rating', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'Home goods department item.' }],
+    });
+
+    const result = await guessReceiptCode('fake-key', 'Target', 'DEPT 42');
+    expect(result?.description).toBe('Home goods department item.');
+    expect(result?.confidence).toBeUndefined();
+  });
+
+  it('returns null when model says Unknown', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'Unknown\nLOW' }],
+    });
+
+    const result = await guessReceiptCode('fake-key', 'Mystery Store', 'XYZ-999');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when response has no text block', async () => {
+    mockCreate.mockResolvedValueOnce({ content: [] });
+
+    const result = await guessReceiptCode('fake-key', 'Ross', 'PANTS LADIES');
+    expect(result).toBeNull();
+  });
+
+  it('passes the correct model and store/code context to the API', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'A thing.\nHIGH' }],
+    });
+
+    await guessReceiptCode('test-key', 'Burlington', 'DEPT 10');
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'claude-haiku-4-5',
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: 'user',
+            content: expect.stringContaining('Burlington'),
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('handles multi-line description before confidence rating', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [
+        {
+          type: 'text',
+          text: 'This is line one of the description.\nThis is line two.\nHIGH',
+        },
+      ],
+    });
+
+    const result = await guessReceiptCode('fake-key', 'TJ Maxx', '284070725');
+    expect(result?.description).toBe(
+      'This is line one of the description. This is line two.'
+    );
+    expect(result?.confidence).toBe('high');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a local SQLite `receipt_codes` table mapping `(store, code)` → description + category — grows automatically as you process receipts
- Press `l` in the TUI to open a lookup pane scoped to the current transaction's payee; flows through exact match → partial match → miss (manual entry or opt-in Claude Haiku guess)
- Adds `ynab-blaster codes list <store>` and `ynab-blaster codes edit` CLI subcommands (YAML round-trip editor)
- LLM fallback is opt-in per lookup and always requires explicit user confirmation before saving

Closes #6.

## Acceptance Criteria

- [ ] `receipt_codes` table created & migrated — verify: `sqlite3 ~/.local/share/ynab-blaster/db.sqlite ".schema receipt_codes"` shows the table with `store_name`, `code`, `description`, `suggested_category_id`, `times_seen`, `first_seen`, `last_seen` columns
- [ ] Press `l` in the TUI on a transaction with a payee → lookup pane opens pre-scoped to that store
- [ ] Press `l` on a transaction with **no payee** → pane opens with a "Store name:" prompt; lookup proceeds after you type a store name
- [ ] Type a code you've saved before → exact match shown with description; press `a` to apply saved category
- [ ] Type a partial fragment of a saved code → up to 5 similar codes shown; navigate with ↑/↓ and Enter to select
- [ ] Type a code that doesn't exist → "no match" state shown with `[m]` and (if API key set) `[l]` options
- [ ] Press `m` on a miss → type description → pick category via the existing picker → code is saved; next time the same code shows as an exact match
- [ ] `times_seen` increments on repeated lookups of the same code — verify with two lookups then `sqlite3 ... "SELECT times_seen FROM receipt_codes WHERE code='YOUR CODE'"`
- [ ] LLM fallback (`l` on miss) requires explicit `y` before anything is saved — pressing `n` discards the guess and drops to manual entry
- [ ] `ynab-blaster codes list <store>` prints all codes for that store (case-insensitive)
- [ ] `ynab-blaster codes edit` opens a YAML file in your `$EDITOR`; saving changes re-imports the dictionary; a YAML parse error leaves the DB untouched

## Test plan

- [ ] `npm run build` — TypeScript compiles cleanly
- [ ] `npm test` — all 77 tests pass (11 test files)
- [ ] Manual: run `npm run dev`, press `l`, walk through exact/partial/miss/manual flows
- [ ] Manual: `ynab-blaster codes list "ross"` shows entries after saving a few codes
- [ ] Manual: `ynab-blaster codes edit` opens editor and round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)