### PR TITLE
feat: receipt scan + OCR suggestions via Continuity Camera

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "postbuild": "chmod +x dist/cli.js",
+    "postbuild": "chmod +x dist/cli.js && mkdir -p dist/native && cp src/native/ocr.swift dist/native/ocr.swift",
     "install-local": "npm run build && npm link",
     "dev": "tsx src/cli.ts",
     "test": "vitest run",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,14 @@ program
     await runRetryInflight();
   });
 
+program
+  .command('install-shortcut')
+  .description('Open or print steps for installing the Continuity Camera shortcut used by [r]')
+  .action(async () => {
+    const { runInstallShortcut } = await import('./commands/install-shortcut.js');
+    await runInstallShortcut();
+  });
+
 // Default command (no subcommand) — runs the TUI blaster.
 program
   .command('run', { isDefault: true, hidden: true })

--- a/src/commands/install-shortcut.ts
+++ b/src/commands/install-shortcut.ts
@@ -1,0 +1,53 @@
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { existsSync } from 'fs';
+
+// Tries to open the bundled `.shortcut` file in the macOS Shortcuts app, which
+// presents the user with the standard "Add Shortcut" sheet. If the bundle is
+// missing (we don't always commit one), falls back to printing the steps the
+// user can follow to assemble a 3-action shortcut by hand.
+//
+// The shortcut needs to:
+//   1) Take Photo (source: any connected iPhone, no preview)
+//   2) Save File / Get Path  (or just pass the photo through)
+//   3) Stop and Output (return the photo) — so `shortcuts run --output-path`
+//      writes the captured image to the path we hand it.
+function resolveShortcutBundle(): string | null {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(here, '..', '..', 'docs', 'shortcuts', 'ynab-blaster-receipt.shortcut'),
+    join(here, '..', '..', '..', 'docs', 'shortcuts', 'ynab-blaster-receipt.shortcut'),
+  ];
+  for (const c of candidates) if (existsSync(c)) return c;
+  return null;
+}
+
+function printManualSteps(): void {
+  const lines = [
+    '',
+    'No bundled shortcut found. Create one by hand:',
+    '',
+    '  1. Open the macOS Shortcuts app.',
+    '  2. New Shortcut, name it: ynab-blaster-receipt',
+    '  3. Add action: "Take Photo".',
+    '       - Source: any connected iPhone (Continuity Camera).',
+    '       - Show Camera Preview: off',
+    '  4. Add action: "Stop and Output" with the photo as the input.',
+    '  5. Save. The shortcut should produce a single image as its output.',
+    '',
+    'Verify with: `shortcuts run "ynab-blaster-receipt" --output-path /tmp/test.jpg`',
+    '',
+  ];
+  for (const l of lines) console.log(l);
+}
+
+export async function runInstallShortcut(): Promise<void> {
+  const bundle = resolveShortcutBundle();
+  if (!bundle) {
+    printManualSteps();
+    return;
+  }
+  console.log(`Opening ${bundle} in Shortcuts.app — confirm the install prompt.`);
+  spawn('open', [bundle], { stdio: 'inherit', detached: true }).unref();
+}

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -7,7 +7,8 @@ import { createYnabClient } from '../ynab.js';
 import { listInflight } from '../db/inflight.js';
 import { replayInflightWrites } from '../replay.js';
 import { syncFromYnab } from '../sync.js';
-import { App } from '../tui/App.js';
+import { App, WRONG_CATEGORY_NAME } from '../tui/App.js';
+import { getCategoryByName } from '../db/categories.js';
 import { createInterface } from 'readline';
 
 // Prompts user with a yes/no question. Returns true if they answer 'y'.
@@ -45,6 +46,17 @@ export async function runBlaster(): Promise<void> {
   await syncFromYnab(db, api, config);
   process.stdout.write(' done.\n');
 
+  // Resolve the "Wrong Category" target up front so the `w` keybind can fire
+  // without re-querying. Fail fast if the category is missing from the budget.
+  const wrongCategory = getCategoryByName(db, WRONG_CATEGORY_NAME);
+  if (!wrongCategory) {
+    console.error(
+      `Error: required category "${WRONG_CATEGORY_NAME}" was not found in your budget. ` +
+        `Create it in YNAB and re-run.`
+    );
+    process.exit(1);
+  }
+
   // Mount the Ink TUI.
-  render(React.createElement(App, { db, api, config }));
+  render(React.createElement(App, { db, api, config, wrongCategory }));
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs';
 import { homedir } from 'os';
 import { load } from 'js-yaml';
+import type { ReceiptConfig, KeywordRule } from './receipt/types.js';
 
 export type SortOrder = 'date_desc' | 'date_asc' | 'account';
 
@@ -10,10 +11,59 @@ export interface Config {
   db_path: string;
   include_hidden_categories: boolean;
   sort: SortOrder;
+  receipt: ReceiptConfig | null;
 }
 
 const VALID_SORTS: SortOrder[] = ['date_desc', 'date_asc', 'account'];
 const CONFIG_PATH = `${homedir()}/.config/ynab-blaster/config.yml`;
+
+const DEFAULT_KEYWORD_MAP: KeywordRule[] = [
+  { keywords: ['grocer', 'produce', 'dairy', 'bakery', 'deli', 'meat'], category: 'Groceries' },
+  { keywords: ['pharmacy', 'rx', 'prescription'], category: 'Pharmacy' },
+  { keywords: ['gas', 'fuel', 'unleaded', 'diesel'], category: 'Gas' },
+  { keywords: ['restaurant', 'cafe', 'coffee', 'bistro', 'grill'], category: 'Eating Out' },
+];
+
+// Validates and shapes the optional `receipt` block. Returns null when the
+// block is absent, so callers can branch on `config.receipt === null` instead
+// of probing each sub-key.
+function parseReceipt(raw: unknown): ReceiptConfig | null {
+  if (raw === undefined || raw === null) {
+    return {
+      enabled: true,
+      shortcut_name: 'ynab-blaster-receipt',
+      temp_dir: '~/.cache/ynab-blaster',
+      keyword_map: DEFAULT_KEYWORD_MAP,
+    };
+  }
+  if (typeof raw !== 'object') {
+    throw new Error('Config error: receipt must be a mapping');
+  }
+  const r = raw as Record<string, unknown>;
+  const enabled = (r.enabled as boolean | undefined) ?? true;
+  const shortcut_name = (r.shortcut_name as string | undefined) ?? 'ynab-blaster-receipt';
+  const temp_dir = (r.temp_dir as string | undefined) ?? '~/.cache/ynab-blaster';
+  const rawMap = r.keyword_map as unknown;
+  let keyword_map: KeywordRule[] = DEFAULT_KEYWORD_MAP;
+  if (Array.isArray(rawMap)) {
+    keyword_map = rawMap.map((entry, i) => {
+      if (
+        typeof entry !== 'object' ||
+        entry === null ||
+        !Array.isArray((entry as Record<string, unknown>).keywords) ||
+        typeof (entry as Record<string, unknown>).category !== 'string'
+      ) {
+        throw new Error(`Config error: receipt.keyword_map[${i}] must have keywords[] and category string`);
+      }
+      const e = entry as { keywords: unknown[]; category: string };
+      return {
+        keywords: e.keywords.map((k) => String(k)),
+        category: e.category,
+      };
+    });
+  }
+  return { enabled, shortcut_name, temp_dir, keyword_map };
+}
 
 // Validates and coerces a raw YAML-parsed object into a typed Config.
 // Throws with a descriptive message pointing to the offending key.
@@ -37,6 +87,7 @@ export function parseConfig(raw: Record<string, unknown>): Config {
     db_path: (raw.db_path as string).replace('~', homedir()),
     include_hidden_categories: (raw.include_hidden_categories as boolean) ?? false,
     sort,
+    receipt: parseReceipt(raw.receipt),
   };
 }
 

--- a/src/db/categories.ts
+++ b/src/db/categories.ts
@@ -42,6 +42,19 @@ export function getCategories(
   return db.prepare(sql).all() as CategoryRow[];
 }
 
+// Looks up a single non-deleted category by exact name. Includes hidden
+// categories so the lookup remains stable even if the user has hidden the
+// category in YNAB. Returns null when no match is found.
+export function getCategoryByName(
+  db: Database.Database,
+  name: string
+): CategoryRow | null {
+  const row = db
+    .prepare('SELECT * FROM categories WHERE name = ? AND deleted = 0 LIMIT 1')
+    .get(name) as CategoryRow | undefined;
+  return row ?? null;
+}
+
 // Group names that YNAB treats as system/internal and that we pin to the top
 // of the picker so they appear in the same position as in the YNAB web UI.
 // Preserving array order defines the pin order.

--- a/src/native/ocr.swift
+++ b/src/native/ocr.swift
@@ -1,0 +1,55 @@
+// macOS Vision-framework OCR helper. Reads a single image path from argv[1],
+// runs VNRecognizeTextRequest with accurate recognition + language correction,
+// prints one recognized line per stdout line, and exits non-zero on failure.
+//
+// Invoked from TypeScript via `swift <repo>/src/native/ocr.swift <jpg-path>`.
+// Requires macOS 12+ and Xcode Command Line Tools (`xcode-select --install`).
+
+import Foundation
+import Vision
+import AppKit
+
+func die(_ msg: String, code: Int32 = 1) -> Never {
+    FileHandle.standardError.write(Data((msg + "\n").utf8))
+    exit(code)
+}
+
+guard CommandLine.arguments.count >= 2 else {
+    die("usage: ocr.swift <image-path>", code: 2)
+}
+
+let path = CommandLine.arguments[1]
+let url = URL(fileURLWithPath: path)
+
+guard FileManager.default.fileExists(atPath: path) else {
+    die("ocr: file not found: \(path)", code: 2)
+}
+
+guard let image = NSImage(contentsOf: url),
+      let tiff = image.tiffRepresentation,
+      let bitmap = NSBitmapImageRep(data: tiff),
+      let cgImage = bitmap.cgImage else {
+    die("ocr: could not decode image: \(path)", code: 3)
+}
+
+let request = VNRecognizeTextRequest()
+request.recognitionLevel = .accurate
+request.usesLanguageCorrection = true
+request.recognitionLanguages = ["en-US"]
+
+let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+do {
+    try handler.perform([request])
+} catch {
+    die("ocr: \(error.localizedDescription)", code: 4)
+}
+
+guard let observations = request.results else {
+    exit(0)
+}
+
+for obs in observations {
+    if let line = obs.topCandidates(1).first?.string {
+        print(line)
+    }
+}

--- a/src/receipt/capture.ts
+++ b/src/receipt/capture.ts
@@ -1,0 +1,88 @@
+import { spawn } from 'child_process';
+import { mkdirSync, existsSync, unlinkSync, statSync } from 'fs';
+import { dirname, join } from 'path';
+import { homedir } from 'os';
+import { CaptureError } from './types.js';
+
+// Resolves leading `~` in a path the same way config.ts does.
+function expandHome(p: string): string {
+  return p.replace(/^~/, homedir());
+}
+
+// Runs a shell command, capturing stdout/stderr and exit code.
+function spawnP(
+  cmd: string,
+  args: string[]
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args);
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => (stdout += d.toString()));
+    child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code: code ?? -1, stdout, stderr }));
+  });
+}
+
+// Returns true when a shortcut with the given name is installed locally.
+async function shortcutExists(name: string): Promise<boolean> {
+  const { code, stdout } = await spawnP('shortcuts', ['list']);
+  if (code !== 0) return false;
+  return stdout
+    .split('\n')
+    .map((s) => s.trim())
+    .includes(name);
+}
+
+export interface CaptureOptions {
+  shortcutName: string;
+  tempDir: string;
+}
+
+// Triggers the user's Continuity Camera shortcut and returns the path to the
+// captured image. The shortcut must be configured to take a photo (Continuity
+// source) and produce that photo as its output.
+//
+// Throws CaptureError with a kind discriminator so the caller can render the
+// appropriate UI hint (install the shortcut, or surface the user's cancel).
+export async function captureReceipt(opts: CaptureOptions): Promise<string> {
+  const tempDir = expandHome(opts.tempDir);
+  mkdirSync(tempDir, { recursive: true });
+  const outPath = join(tempDir, `receipt-${Date.now()}.jpg`);
+  mkdirSync(dirname(outPath), { recursive: true });
+
+  if (!(await shortcutExists(opts.shortcutName))) {
+    throw new CaptureError(
+      'shortcut-missing',
+      `Shortcut "${opts.shortcutName}" not found. Run "ynab-blaster install-shortcut" for setup steps.`
+    );
+  }
+
+  // Pre-clean any stale path so we can detect "shortcut produced no file".
+  if (existsSync(outPath)) unlinkSync(outPath);
+
+  const { code, stderr } = await spawnP('shortcuts', [
+    'run',
+    opts.shortcutName,
+    '--output-path',
+    outPath,
+  ]);
+
+  if (code !== 0) {
+    const msg = stderr.trim() || `shortcuts run exited with ${code}`;
+    if (/cancel/i.test(msg)) {
+      throw new CaptureError('shortcut-cancelled', 'Capture cancelled.');
+    }
+    throw new CaptureError('shortcut-failed', msg);
+  }
+
+  if (!existsSync(outPath) || statSync(outPath).size === 0) {
+    throw new CaptureError(
+      'output-missing',
+      'Shortcut completed but did not produce an image. Check the shortcut: it must end with "Stop and Output" emitting the photo.'
+    );
+  }
+
+  return outPath;
+}

--- a/src/receipt/ocr.ts
+++ b/src/receipt/ocr.ts
@@ -1,0 +1,73 @@
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { existsSync } from 'fs';
+import { OcrError } from './types.js';
+
+// Resolves the bundled Swift script. Works under both `tsx` (src tree) and
+// the compiled `dist` tree because we copy ocr.swift into dist/native via
+// the build step. We probe both locations.
+function resolveSwiftScript(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    // dist tree: dist/receipt/ocr.js -> dist/native/ocr.swift
+    join(here, '..', 'native', 'ocr.swift'),
+    // src tree (tsx dev): src/receipt/ocr.ts -> src/native/ocr.swift
+    join(here, '..', '..', 'src', 'native', 'ocr.swift'),
+  ];
+  for (const c of candidates) if (existsSync(c)) return c;
+  return candidates[0]!;
+}
+
+function spawnP(
+  cmd: string,
+  args: string[]
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args);
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => (stdout += d.toString()));
+    child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code: code ?? -1, stdout, stderr }));
+  });
+}
+
+// Runs the bundled Vision OCR Swift script against an image and returns the
+// recognized lines, top to bottom. Throws OcrError with a kind discriminator
+// so the caller can show actionable hints (install Xcode CLT, retake, etc.).
+export async function runOcr(imagePath: string): Promise<string[]> {
+  const script = resolveSwiftScript();
+
+  let result: { code: number; stdout: string; stderr: string };
+  try {
+    result = await spawnP('swift', [script, imagePath]);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/ENOENT/.test(msg)) {
+      throw new OcrError(
+        'swift-missing',
+        'swift not found on PATH. Install Xcode Command Line Tools: xcode-select --install'
+      );
+    }
+    throw new OcrError('ocr-failed', msg);
+  }
+
+  if (result.code !== 0) {
+    throw new OcrError(
+      'ocr-failed',
+      result.stderr.trim() || `swift exited with code ${result.code}`
+    );
+  }
+
+  const lines = result.stdout
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  if (lines.length === 0) {
+    throw new OcrError('no-text', 'No text recognized. Try better lighting or a flatter receipt.');
+  }
+  return lines;
+}

--- a/src/receipt/parse.ts
+++ b/src/receipt/parse.ts
@@ -1,0 +1,174 @@
+import type { ParsedReceipt, ReceiptItem } from './types.js';
+
+// Regexes used by the parser. Kept local + named so the heuristics stay readable.
+// Vision OCR tends to emit one logical line per array entry, but item rows can
+// either come back joined ("MILK 2%   3.99") or split across two lines
+// ("MILK 2%" + "3.99"). We handle both shapes.
+
+const AMOUNT_TAIL = /^(.*?)[ \t]+\$?(-?\d{1,3}(?:,\d{3})*\.\d{2})$/;
+const AMOUNT_ONLY = /^\$?(-?\d{1,3}(?:,\d{3})*\.\d{2})$/;
+const DATE_PATTERNS: { re: RegExp; toIso: (m: RegExpMatchArray) => string | null }[] = [
+  // 2026-04-15 / 2026/04/15
+  {
+    re: /\b(20\d{2})[-/](\d{1,2})[-/](\d{1,2})\b/,
+    toIso: (m) => isoFromYmd(+m[1]!, +m[2]!, +m[3]!),
+  },
+  // 04/15/2026 or 4-15-26
+  {
+    re: /\b(\d{1,2})[-/](\d{1,2})[-/](\d{2}|\d{4})\b/,
+    toIso: (m) => {
+      const yr = m[3]!.length === 2 ? 2000 + +m[3]! : +m[3]!;
+      return isoFromYmd(yr, +m[1]!, +m[2]!);
+    },
+  },
+];
+
+const TOTAL_KEYWORDS = /\b(grand\s*total|total\s*due|amount\s*due|total|balance|amt)\b/i;
+const SUBTOTAL_KEYWORDS = /\b(sub[\s-]?total|tax|change|tender|cash|debit|credit|visa|mastercard|amex)\b/i;
+
+function isoFromYmd(y: number, m: number, d: number): string | null {
+  if (m < 1 || m > 12 || d < 1 || d > 31) return null;
+  const mm = String(m).padStart(2, '0');
+  const dd = String(d).padStart(2, '0');
+  return `${y}-${mm}-${dd}`;
+}
+
+function toMilliunits(amountStr: string): number {
+  // amountStr is the raw decimal capture, possibly with comma thousand separators.
+  const cleaned = amountStr.replace(/,/g, '');
+  return Math.round(parseFloat(cleaned) * 1000);
+}
+
+// Pulls the first plausible date out of the OCR lines.
+function detectDate(lines: string[]): string | null {
+  for (const line of lines) {
+    for (const p of DATE_PATTERNS) {
+      const m = line.match(p.re);
+      if (m) {
+        const iso = p.toIso(m);
+        if (iso) return iso;
+      }
+    }
+  }
+  return null;
+}
+
+// Best-guess merchant: scan top of receipt for the first line that's mostly
+// letters and isn't an obvious address / phone / item / amount.
+function detectMerchant(lines: string[]): string | null {
+  const head = lines.slice(0, Math.min(8, lines.length));
+  for (const raw of head) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (AMOUNT_ONLY.test(line)) continue;
+    if (AMOUNT_TAIL.test(line)) continue;
+    if (/^\d/.test(line)) continue; // address line
+    if (/^\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}/.test(line)) continue; // phone
+    const letters = line.replace(/[^a-zA-Z]/g, '').length;
+    if (letters < 3) continue;
+    return line;
+  }
+  return head[0]?.trim() ?? null;
+}
+
+// Strips obvious sentinels from a description: leading qty markers, trailing
+// SKU codes, and "@ $X.XX EA" suffixes.
+function cleanDescription(desc: string): string {
+  return desc
+    .replace(/\s+@\s+\$?\d+(?:\.\d{2})?(?:\s*\/?\s*EA)?$/i, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
+// Item detection: walks the lines top-to-bottom, joining "<desc>\n<amount>" pairs
+// when the amount lives on its own line, and treating "<desc>  <amount>" as a
+// single-line item. Lines that look like totals/tax/subtotals are excluded.
+function detectItems(lines: string[]): { items: ReceiptItem[]; totalCandidates: { value: number; line: string }[] } {
+  const items: ReceiptItem[] = [];
+  const totalCandidates: { value: number; line: string }[] = [];
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i]!;
+    const tail = line.match(AMOUNT_TAIL);
+    const onlyAmount = line.match(AMOUNT_ONLY);
+
+    if (tail) {
+      const desc = cleanDescription(tail[1]!);
+      const value = toMilliunits(tail[2]!);
+      if (TOTAL_KEYWORDS.test(line)) {
+        totalCandidates.push({ value, line });
+      } else if (!SUBTOTAL_KEYWORDS.test(line) && desc.length > 0) {
+        items.push({ description: desc, amount_milliunits: -Math.abs(value) });
+      }
+      i += 1;
+      continue;
+    }
+
+    if (onlyAmount && i > 0) {
+      const prev = lines[i - 1]!;
+      const value = toMilliunits(onlyAmount[1]!);
+      const combined = `${prev} ${line}`;
+      if (TOTAL_KEYWORDS.test(prev)) {
+        totalCandidates.push({ value, line: combined });
+      } else if (!SUBTOTAL_KEYWORDS.test(prev)) {
+        const desc = cleanDescription(prev);
+        if (
+          desc.length > 0 &&
+          // Don't double-count: only consume `prev` if the previous push didn't
+          // already cover it.
+          (items.length === 0 || items[items.length - 1]!.description !== desc)
+        ) {
+          items.push({ description: desc, amount_milliunits: -Math.abs(value) });
+        }
+      }
+      i += 1;
+      continue;
+    }
+
+    i += 1;
+  }
+  return { items, totalCandidates };
+}
+
+// Picks the best total from the candidates. Preference order:
+//   1. Highest-magnitude line that explicitly says "grand total".
+//   2. Highest-magnitude line containing any total keyword.
+//   3. Largest amount-only line in the bottom third of the receipt.
+function detectTotal(
+  totalCandidates: { value: number; line: string }[],
+  lines: string[]
+): number | null {
+  const grand = totalCandidates.filter((c) => /grand\s*total/i.test(c.line));
+  if (grand.length > 0) {
+    return -Math.max(...grand.map((c) => Math.abs(c.value)));
+  }
+  if (totalCandidates.length > 0) {
+    return -Math.max(...totalCandidates.map((c) => Math.abs(c.value)));
+  }
+  // Last-resort fallback: largest amount in the bottom third, ignoring tax/etc.
+  const tail = lines.slice(Math.floor(lines.length * 2 / 3));
+  const amounts: number[] = [];
+  for (const l of tail) {
+    if (SUBTOTAL_KEYWORDS.test(l)) continue;
+    const m = l.match(AMOUNT_ONLY) ?? l.match(AMOUNT_TAIL);
+    if (m) amounts.push(toMilliunits(m[m.length - 1]!));
+  }
+  if (amounts.length === 0) return null;
+  return -Math.max(...amounts);
+}
+
+// Pure heuristic parser. Takes the raw OCR lines (already trimmed and
+// non-empty) and produces a best-effort structured receipt. Designed to be
+// robust against the worst-case OCR output rather than perfect against ideal
+// receipts.
+export function parseReceipt(lines: string[]): ParsedReceipt {
+  if (lines.length === 0) {
+    return { merchant: null, date: null, total_milliunits: null, items: [], raw_lines: [] };
+  }
+  const merchant = detectMerchant(lines);
+  const date = detectDate(lines);
+  const { items, totalCandidates } = detectItems(lines);
+  const total_milliunits = detectTotal(totalCandidates, lines);
+  return { merchant, date, total_milliunits, items, raw_lines: lines };
+}

--- a/src/receipt/suggest.ts
+++ b/src/receipt/suggest.ts
@@ -1,0 +1,197 @@
+import type { CategoryRow } from '../db/categories.js';
+import type { HistoryRow } from '../db/history.js';
+import type { TransactionRow } from '../db/transactions.js';
+import type {
+  KeywordRule,
+  ParsedReceipt,
+  ReceiptSuggestion,
+  SuggestionReason,
+} from './types.js';
+
+// Tolerance when comparing the receipt's detected total to the YNAB
+// transaction amount. OCR drops decimal points; payees post tips as separate
+// lines; fees post on a different day. 50¢ is generous enough to absorb
+// rounding without hiding "wrong receipt" mistakes.
+const TOTAL_TOLERANCE_MILLIUNITS = 500;
+
+// Threshold for declaring a payee-history suggestion a strong match.
+// Below this, we still surface the suggestion but flag it as weak so the
+// keyword fallback can override.
+const PAYEE_HISTORY_MIN_PCT = 50;
+
+interface SuggestInputs {
+  parsed: ParsedReceipt;
+  transaction: TransactionRow;
+  categories: CategoryRow[];
+  history: HistoryRow[]; // payee history rows for transaction.payee_id
+  keywordMap: KeywordRule[];
+}
+
+function payeeHistorySuggestion(
+  history: HistoryRow[],
+  categories: CategoryRow[]
+): { id: string; name: string; pct: number; count: number } | null {
+  if (history.length === 0) return null;
+  const total = history.reduce((sum, h) => sum + h.count, 0);
+  if (total === 0) return null;
+  const top = history[0]!;
+  const cat = categories.find((c) => c.id === top.category_id);
+  if (!cat) return null;
+  return {
+    id: cat.id,
+    name: cat.name,
+    pct: Math.round((top.count / total) * 100),
+    count: top.count,
+  };
+}
+
+function keywordSuggestion(
+  parsed: ParsedReceipt,
+  categories: CategoryRow[],
+  keywordMap: KeywordRule[]
+): { id: string; name: string; keyword: string } | null {
+  if (keywordMap.length === 0) return null;
+  const haystack = [
+    parsed.merchant ?? '',
+    ...parsed.items.map((i) => i.description),
+    ...parsed.raw_lines,
+  ]
+    .join(' ')
+    .toLowerCase();
+  for (const rule of keywordMap) {
+    for (const kw of rule.keywords) {
+      const needle = kw.toLowerCase();
+      if (haystack.includes(needle)) {
+        const cat = categories.find(
+          (c) => c.name.toLowerCase() === rule.category.toLowerCase()
+        );
+        if (cat) {
+          return { id: cat.id, name: cat.name, keyword: kw };
+        }
+      }
+    }
+  }
+  return null;
+}
+
+// Compares the detected merchant string to the transaction's payee name.
+// Loose normalization: case, punctuation, store numbers all stripped.
+function compareMerchant(
+  detected: string | null,
+  payeeName: string | null
+): 'matches' | 'differs' | 'unknown' {
+  if (!detected || !payeeName) return 'unknown';
+  const norm = (s: string) =>
+    s
+      .toLowerCase()
+      .replace(/#\s*\d+/g, '')
+      .replace(/[^a-z0-9 ]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  const a = norm(detected);
+  const b = norm(payeeName);
+  if (!a || !b) return 'unknown';
+  if (a === b) return 'matches';
+  if (a.includes(b) || b.includes(a)) return 'matches';
+  // First two tokens overlap is a soft match (TARGET 1234 vs TARGET STORE).
+  const aHead = a.split(' ').slice(0, 2).join(' ');
+  const bHead = b.split(' ').slice(0, 2).join(' ');
+  if (aHead === bHead && aHead.length > 2) return 'matches';
+  return 'differs';
+}
+
+function compareDate(
+  detected: string | null,
+  txDate: string
+): 'matches' | 'differs' | 'unknown' {
+  if (!detected) return 'unknown';
+  if (detected === txDate) return 'matches';
+  // Soft tolerance: same date within 3 days handles weekend posting drift.
+  const a = new Date(detected).getTime();
+  const b = new Date(txDate).getTime();
+  if (!Number.isNaN(a) && !Number.isNaN(b)) {
+    const diffDays = Math.abs(a - b) / (1000 * 60 * 60 * 24);
+    if (diffDays <= 3) return 'matches';
+  }
+  return 'differs';
+}
+
+// Pure suggestion logic. Inputs are the parsed receipt, the current
+// transaction, the full category list, the transaction's payee history rows,
+// and the user's keyword map. Output is the suggested category plus a bag of
+// derived comparisons used by the UI (merchant/date/total match flags).
+export function suggestFromReceipt(inputs: SuggestInputs): ReceiptSuggestion {
+  const { parsed, transaction, categories, history, keywordMap } = inputs;
+
+  // Match flags first — independent of which suggestion source wins.
+  const merchant_match = compareMerchant(parsed.merchant, transaction.payee_name);
+  const date_match = compareDate(parsed.date, transaction.date);
+
+  let total_diff_milliunits = 0;
+  let total_mismatch = false;
+  if (parsed.total_milliunits !== null) {
+    total_diff_milliunits = parsed.total_milliunits - transaction.amount;
+    total_mismatch = Math.abs(total_diff_milliunits) > TOTAL_TOLERANCE_MILLIUNITS;
+  }
+
+  // 1. Payee history (strong)
+  const fromHistory = payeeHistorySuggestion(history, categories);
+  if (fromHistory && fromHistory.pct >= PAYEE_HISTORY_MIN_PCT) {
+    const reason: SuggestionReason = {
+      kind: 'payee_history',
+      pct: fromHistory.pct,
+      count: fromHistory.count,
+    };
+    return {
+      category_id: fromHistory.id,
+      category_name: fromHistory.name,
+      reason,
+      total_mismatch,
+      total_diff_milliunits,
+      merchant_match,
+      date_match,
+    };
+  }
+
+  // 2. Keyword map fallback
+  const fromKeyword = keywordSuggestion(parsed, categories, keywordMap);
+  if (fromKeyword) {
+    return {
+      category_id: fromKeyword.id,
+      category_name: fromKeyword.name,
+      reason: { kind: 'keyword', keyword: fromKeyword.keyword },
+      total_mismatch,
+      total_diff_milliunits,
+      merchant_match,
+      date_match,
+    };
+  }
+
+  // 3. Weak payee history (still better than nothing)
+  if (fromHistory) {
+    const reason: SuggestionReason = {
+      kind: 'payee_history',
+      pct: fromHistory.pct,
+      count: fromHistory.count,
+    };
+    return {
+      category_id: fromHistory.id,
+      category_name: fromHistory.name,
+      reason,
+      total_mismatch,
+      total_diff_milliunits,
+      merchant_match,
+      date_match,
+    };
+  }
+
+  return {
+    category_id: null,
+    category_name: null,
+    reason: { kind: 'none' },
+    total_mismatch,
+    total_diff_milliunits,
+    merchant_match,
+    date_match,
+  };
+}

--- a/src/receipt/types.ts
+++ b/src/receipt/types.ts
@@ -1,0 +1,65 @@
+// Shared types for the receipt-scan pipeline.
+// The pipeline runs: capture (Continuity Camera shortcut) -> ocr (Swift Vision)
+// -> parse (heuristic) -> suggest (payee history + keyword map).
+
+export interface ReceiptItem {
+  description: string;
+  amount_milliunits: number; // signed: negative for outflow, matches YNAB convention
+}
+
+export interface ParsedReceipt {
+  merchant: string | null;
+  date: string | null; // ISO yyyy-mm-dd when detectable
+  total_milliunits: number | null; // negative; aligns with YNAB tx amount
+  items: ReceiptItem[];
+  raw_lines: string[];
+}
+
+export type SuggestionReason =
+  | { kind: 'payee_history'; pct: number; count: number }
+  | { kind: 'keyword'; keyword: string }
+  | { kind: 'none' };
+
+export interface ReceiptSuggestion {
+  category_id: string | null;
+  category_name: string | null;
+  reason: SuggestionReason;
+  total_mismatch: boolean;
+  total_diff_milliunits: number; // detected_total - tx_amount; 0 when no detected total
+  merchant_match: 'matches' | 'differs' | 'unknown';
+  date_match: 'matches' | 'differs' | 'unknown';
+}
+
+export interface KeywordRule {
+  keywords: string[];
+  category: string; // category name (resolved to id at suggest time)
+}
+
+export interface ReceiptConfig {
+  enabled: boolean;
+  shortcut_name: string;
+  temp_dir: string;
+  keyword_map: KeywordRule[];
+}
+
+export type CaptureErrorKind =
+  | 'shortcut-missing'
+  | 'shortcut-cancelled'
+  | 'shortcut-failed'
+  | 'output-missing';
+
+export class CaptureError extends Error {
+  constructor(public kind: CaptureErrorKind, message: string) {
+    super(message);
+    this.name = 'CaptureError';
+  }
+}
+
+export type OcrErrorKind = 'swift-missing' | 'ocr-failed' | 'no-text';
+
+export class OcrError extends Error {
+  constructor(public kind: OcrErrorKind, message: string) {
+    super(message);
+    this.name = 'OcrError';
+  }
+}

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -13,18 +13,25 @@ import { ErrorBanner } from './ErrorBanner.js';
 import { WriteStatus } from './WriteStatus.js';
 import { WriteManager } from '../write-manager.js';
 import { getUnapprovedTransactions } from '../db/transactions.js';
-import { getCategories, getCategoriesGrouped } from '../db/categories.js';
+import { getCategories, getCategoriesGrouped, type CategoryRow } from '../db/categories.js';
 import { getPayeeHistory } from '../db/history.js';
+
+// Hardcoded name of the YNAB category used by the `w` keybind to mark a
+// transaction as having an unknown / to-be-reviewed category. Resolved once
+// at startup in run.ts; missing-category causes the app to exit before the
+// TUI mounts.
+export const WRONG_CATEGORY_NAME = '\u{1F4B5} Wrong Category';
 
 interface Props {
   db: Database.Database;
   api: ynab.API;
   config: Config;
+  wrongCategory: CategoryRow;
 }
 
 // Root App component. Owns all state via useReducer.
 // Wires WriteManager calls to keybindings and dispatches state transitions.
-export function App({ db, api, config }: Props) {
+export function App({ db, api, config, wrongCategory }: Props) {
   const [state, dispatch] = useReducer(reducer, initialState);
   const { exit } = useApp();
 
@@ -76,6 +83,7 @@ export function App({ db, api, config }: Props) {
     if (input === 'c') dispatch({ type: 'SET_MODE', mode: 'picker' });
     if (input === 'n') dispatch({ type: 'NEXT' });
     if (input === 's') dispatch({ type: 'NEXT' });
+    if (input === 'w') fireWrite(() => manager.approve(currentTx.id, wrongCategory.id));
     if (input === 'x') fireWrite(() => manager.flagForSplit(currentTx.id));
     if (input === 'm') dispatch({ type: 'SET_MODE', mode: 'memo' });
     if (input === 'u' && state.history.length > 0) dispatch({ type: 'POP_HISTORY' });

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,4 +1,5 @@
 import React, { useReducer, useEffect } from 'react';
+import { unlink } from 'fs/promises';
 import { Box, Text, useInput, useApp } from 'ink';
 import type Database from 'better-sqlite3';
 import type * as ynab from 'ynab';
@@ -9,12 +10,17 @@ import { Footer } from './Footer.js';
 import { DefaultMode } from './DefaultMode.js';
 import { CategoryPicker } from './CategoryPicker.js';
 import { MemoEditor } from './MemoEditor.js';
+import { ReceiptMode } from './ReceiptMode.js';
 import { ErrorBanner } from './ErrorBanner.js';
 import { WriteStatus } from './WriteStatus.js';
 import { WriteManager } from '../write-manager.js';
 import { getUnapprovedTransactions } from '../db/transactions.js';
 import { getCategories, getCategoriesGrouped, type CategoryRow } from '../db/categories.js';
 import { getPayeeHistory } from '../db/history.js';
+import { captureReceipt } from '../receipt/capture.js';
+import { runOcr } from '../receipt/ocr.js';
+import { parseReceipt } from '../receipt/parse.js';
+import { suggestFromReceipt } from '../receipt/suggest.js';
 
 // Hardcoded name of the YNAB category used by the `w` keybind to mark a
 // transaction as having an unknown / to-be-reviewed category. Resolved once
@@ -69,7 +75,62 @@ export function App({ db, api, config, wrongCategory }: Props) {
     }
   };
 
+  // Drives the capture -> OCR -> parse -> suggest pipeline. Each stage emits
+  // a progress dispatch so the TUI shows the right spinner. Temp image is
+  // unlinked best-effort regardless of outcome — we don't persist anything.
+  const fireReceiptScan = async () => {
+    if (!currentTx || !config.receipt) return;
+    dispatch({ type: 'RECEIPT_START' });
+    let imagePath: string | null = null;
+    try {
+      imagePath = await captureReceipt({
+        shortcutName: config.receipt.shortcut_name,
+        tempDir: config.receipt.temp_dir,
+      });
+      dispatch({ type: 'RECEIPT_PROGRESS', stage: 'ocr' });
+      const lines = await runOcr(imagePath);
+      dispatch({ type: 'RECEIPT_PROGRESS', stage: 'analyzing' });
+      const parsed = parseReceipt(lines);
+      const suggestion = suggestFromReceipt({
+        parsed,
+        transaction: currentTx,
+        categories,
+        history: payeeHistory,
+        keywordMap: config.receipt.keyword_map,
+      });
+      dispatch({ type: 'RECEIPT_RESULT', parsed, suggestion });
+    } catch (err) {
+      dispatch({ type: 'RECEIPT_FAIL', error: (err as Error).message });
+    } finally {
+      if (imagePath) {
+        unlink(imagePath).catch(() => {
+          // Discarded by design — log nothing, leak nothing.
+        });
+      }
+    }
+  };
+
   useInput((input, key) => {
+    if (state.mode === 'receipt') {
+      if (key.escape) {
+        dispatch({ type: 'RECEIPT_CLOSE' });
+        return;
+      }
+      if (state.receipt?.stage === 'review') {
+        if (!currentTx) return;
+        const sug = state.receipt.suggestion;
+        if ((input === 'y' || key.return) && sug?.category_id) {
+          dispatch({ type: 'RECEIPT_CLOSE' });
+          fireWrite(() => manager.approve(currentTx.id, sug.category_id!));
+        }
+        if (input === 'c') dispatch({ type: 'SET_MODE', mode: 'picker' });
+      }
+      if (state.receipt?.stage === 'error' && input === 'r') {
+        fireReceiptScan();
+      }
+      return;
+    }
+
     if (state.mode !== 'default') return;
 
     if (input === 'q') exit();
@@ -86,11 +147,13 @@ export function App({ db, api, config, wrongCategory }: Props) {
     if (input === 'w') fireWrite(() => manager.approve(currentTx.id, wrongCategory.id));
     if (input === 'x') fireWrite(() => manager.flagForSplit(currentTx.id));
     if (input === 'm') dispatch({ type: 'SET_MODE', mode: 'memo' });
+    if (input === 'r' && config.receipt?.enabled) fireReceiptScan();
     if (input === 'u' && state.history.length > 0) dispatch({ type: 'POP_HISTORY' });
   });
 
   const handleCategorySelect = (categoryId: string, categoryName: string) => {
     if (!currentTx) return;
+    if (state.receipt) dispatch({ type: 'RECEIPT_CLOSE' });
     dispatch({ type: 'SET_MODE', mode: 'default' });
     fireWrite(() => manager.approve(currentTx.id, categoryId));
   };
@@ -132,7 +195,13 @@ export function App({ db, api, config, wrongCategory }: Props) {
         <CategoryPicker
           groups={categoryGroups}
           onSelect={handleCategorySelect}
-          onCancel={() => dispatch({ type: 'SET_MODE', mode: 'default' })}
+          onCancel={() => {
+            if (state.receipt) {
+              dispatch({ type: 'SET_MODE', mode: 'receipt' });
+            } else {
+              dispatch({ type: 'SET_MODE', mode: 'default' });
+            }
+          }}
         />
       )}
 
@@ -142,6 +211,10 @@ export function App({ db, api, config, wrongCategory }: Props) {
           onSubmit={handleMemoSubmit}
           onCancel={() => dispatch({ type: 'SET_MODE', mode: 'default' })}
         />
+      )}
+
+      {state.mode === 'receipt' && state.receipt && (
+        <ReceiptMode state={state.receipt} transaction={currentTx} />
       )}
 
       <Box justifyContent="space-between">

--- a/src/tui/DefaultMode.tsx
+++ b/src/tui/DefaultMode.tsx
@@ -63,6 +63,7 @@ export function DefaultMode({ transaction, history, categories, suggestedCategor
             <Text dimColor>[y/↵] approve (pick category first)</Text>
           )}
           <Text>[n] next (no change)</Text>
+          <Text>[w] wrong category</Text>
           <Text>[x] flag for split</Text>
           <Text>[u] undo last</Text>
         </Box>

--- a/src/tui/DefaultMode.tsx
+++ b/src/tui/DefaultMode.tsx
@@ -65,6 +65,7 @@ export function DefaultMode({ transaction, history, categories, suggestedCategor
           <Text>[n] next (no change)</Text>
           <Text>[w] wrong category</Text>
           <Text>[x] flag for split</Text>
+          <Text>[r] scan receipt</Text>
           <Text>[u] undo last</Text>
         </Box>
         <Box flexDirection="column">

--- a/src/tui/Footer.tsx
+++ b/src/tui/Footer.tsx
@@ -6,7 +6,7 @@ export function Footer() {
   return (
     <Box flexDirection="column" marginTop={1} borderStyle="single" borderColor="gray">
       <Text dimColor>
-        [y/↵] approve  [c] category  [n] next  [s] skip  [w] wrong cat  [x] flag split  [m] memo  [u] undo  [q] quit
+        [y/↵] approve  [c] category  [n] next  [s] skip  [w] wrong cat  [x] flag split  [m] memo  [r] receipt  [u] undo  [q] quit
       </Text>
     </Box>
   );

--- a/src/tui/Footer.tsx
+++ b/src/tui/Footer.tsx
@@ -6,7 +6,7 @@ export function Footer() {
   return (
     <Box flexDirection="column" marginTop={1} borderStyle="single" borderColor="gray">
       <Text dimColor>
-        [y/↵] approve  [c] category  [n] next  [s] skip  [x] flag split  [m] memo  [u] undo  [q] quit
+        [y/↵] approve  [c] category  [n] next  [s] skip  [w] wrong cat  [x] flag split  [m] memo  [u] undo  [q] quit
       </Text>
     </Box>
   );

--- a/src/tui/ReceiptMode.tsx
+++ b/src/tui/ReceiptMode.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import Spinner from 'ink-spinner';
+import { formatMilliunits } from '../format.js';
+import type { TransactionRow } from '../db/transactions.js';
+import type { ReceiptState } from './reducer.js';
+import type { ReceiptSuggestion, SuggestionReason } from '../receipt/types.js';
+
+interface Props {
+  state: ReceiptState;
+  transaction: TransactionRow;
+}
+
+const MAX_ITEMS_SHOWN = 6;
+
+function reasonText(reason: SuggestionReason): string {
+  if (reason.kind === 'payee_history') {
+    return `payee history: ${reason.pct}% over ${reason.count}`;
+  }
+  if (reason.kind === 'keyword') {
+    return `keyword "${reason.keyword}"`;
+  }
+  return 'no signal — pick a category';
+}
+
+function MatchTag({ status, label }: { status: 'matches' | 'differs' | 'unknown'; label: string }) {
+  if (status === 'matches') return <Text color="green">  ✓ {label}</Text>;
+  if (status === 'differs') return <Text color="red">  ✗ {label}</Text>;
+  return <Text dimColor>  ? {label}</Text>;
+}
+
+function ReviewPanel({ state, transaction }: Props) {
+  const { parsed, suggestion } = state;
+  if (!parsed || !suggestion) return null;
+
+  const detectedTotal =
+    parsed.total_milliunits !== null ? formatMilliunits(parsed.total_milliunits) : '(not detected)';
+  const txAmount = formatMilliunits(transaction.amount);
+
+  return (
+    <Box flexDirection="column">
+      <Text bold>Receipt scanned ─────────────────────────────────────</Text>
+
+      <Box>
+        <Text>  Merchant:  </Text>
+        <Text bold>{parsed.merchant ?? '(not detected)'}</Text>
+        <MatchTag status={suggestion.merchant_match} label={merchantLabel(suggestion.merchant_match, transaction.payee_name)} />
+      </Box>
+
+      <Box>
+        <Text>  Date:      </Text>
+        <Text bold>{parsed.date ?? '(not detected)'}</Text>
+        <MatchTag status={suggestion.date_match} label={dateLabel(suggestion.date_match, transaction.date)} />
+      </Box>
+
+      <Box>
+        <Text>  Total:     </Text>
+        <Text bold>{detectedTotal}</Text>
+        {parsed.total_milliunits !== null ? (
+          suggestion.total_mismatch ? (
+            <Text color="red">  ✗ off by {formatMilliunits(Math.abs(suggestion.total_diff_milliunits))} vs tx {txAmount}</Text>
+          ) : (
+            <Text color="green">  ✓ matches tx {txAmount}</Text>
+          )
+        ) : (
+          <Text dimColor>  ? tx {txAmount}</Text>
+        )}
+      </Box>
+
+      <Box flexDirection="column" marginTop={1}>
+        <Text bold>  Items:</Text>
+        {parsed.items.length === 0 ? (
+          <Text dimColor>    (none parsed)</Text>
+        ) : (
+          <>
+            {parsed.items.slice(0, MAX_ITEMS_SHOWN).map((it, i) => (
+              <Text key={i}>
+                {'    - '}
+                {it.description.padEnd(28).slice(0, 28)}
+                {' '}
+                <Text dimColor>{formatMilliunits(it.amount_milliunits)}</Text>
+              </Text>
+            ))}
+            {parsed.items.length > MAX_ITEMS_SHOWN && (
+              <Text dimColor>{`    … ${parsed.items.length - MAX_ITEMS_SHOWN} more`}</Text>
+            )}
+          </>
+        )}
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        {suggestion.category_name ? (
+          <Text>
+            Suggested: <Text bold color="cyan">{suggestion.category_name}</Text>
+            <Text dimColor>{`  (${reasonText(suggestion.reason)})`}</Text>
+          </Text>
+        ) : (
+          <Text dimColor>No suggestion — press [c] to choose a category</Text>
+        )}
+      </Box>
+
+      <Box marginTop={1}>
+        {suggestion.category_name ? (
+          <Text>[y] approve as <Text bold>{suggestion.category_name}</Text>   [c] change category   [esc] discard</Text>
+        ) : (
+          <Text>[c] choose category   [esc] discard</Text>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+function merchantLabel(status: 'matches' | 'differs' | 'unknown', payee: string | null): string {
+  if (status === 'matches') return `matches payee${payee ? ` (${payee})` : ''}`;
+  if (status === 'differs') return `differs from payee${payee ? ` (${payee})` : ''}`;
+  return payee ? `payee: ${payee}` : 'no payee on tx';
+}
+
+function dateLabel(status: 'matches' | 'differs' | 'unknown', txDate: string): string {
+  if (status === 'matches') return `matches tx (${txDate})`;
+  if (status === 'differs') return `differs from tx (${txDate})`;
+  return `tx: ${txDate}`;
+}
+
+function StageLine({ stage }: { stage: ReceiptState['stage'] }) {
+  const map: Record<ReceiptState['stage'], string> = {
+    capturing: 'Waiting for iPhone capture (open Camera on your phone or run the shortcut)…',
+    ocr: 'Running OCR…',
+    analyzing: 'Analyzing receipt…',
+    review: '',
+    error: '',
+  };
+  if (!map[stage]) return null;
+  return (
+    <Box>
+      <Text color="yellow"><Spinner type="dots" /></Text>
+      <Text>{` ${map[stage]}`}</Text>
+    </Box>
+  );
+}
+
+// Top-level mode component. Switches between progress, review, and error UIs
+// based on `state.stage`. All keybinds are owned by App.tsx — this component
+// is purely presentational.
+export function ReceiptMode({ state, transaction }: Props) {
+  if (state.stage === 'error') {
+    return (
+      <Box flexDirection="column">
+        <Text bold color="red">Receipt scan failed</Text>
+        <Text>  {state.error ?? 'unknown error'}</Text>
+        <Box marginTop={1}><Text>[r] retry   [esc] cancel</Text></Box>
+      </Box>
+    );
+  }
+
+  if (state.stage === 'review') {
+    return <ReviewPanel state={state} transaction={transaction} />;
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Text bold>Receipt scan in progress</Text>
+      <Box marginTop={1}><StageLine stage={state.stage} /></Box>
+      <Box marginTop={1}><Text dimColor>[esc] cancel</Text></Box>
+    </Box>
+  );
+}

--- a/src/tui/reducer.ts
+++ b/src/tui/reducer.ts
@@ -1,7 +1,22 @@
 import type { TransactionRow } from '../db/transactions.js';
+import type { ParsedReceipt, ReceiptSuggestion } from '../receipt/types.js';
 
-export type Mode = 'default' | 'picker' | 'memo';
+export type Mode = 'default' | 'picker' | 'memo' | 'receipt';
 export type WriteStatus = 'idle' | 'saving' | 'saved' | 'failed';
+
+export type ReceiptStage =
+  | 'capturing'
+  | 'ocr'
+  | 'analyzing'
+  | 'review'
+  | 'error';
+
+export interface ReceiptState {
+  stage: ReceiptStage;
+  parsed: ParsedReceipt | null;
+  suggestion: ReceiptSuggestion | null;
+  error: string | null;
+}
 
 export interface AppState {
   queue: TransactionRow[];
@@ -10,6 +25,7 @@ export interface AppState {
   errors: string[];
   writeStatus: WriteStatus;
   history: TransactionRow[];
+  receipt: ReceiptState | null;
 }
 
 export const initialState: AppState = {
@@ -19,6 +35,7 @@ export const initialState: AppState = {
   errors: [],
   writeStatus: 'idle',
   history: [],
+  receipt: null,
 };
 
 export type Action =
@@ -29,7 +46,12 @@ export type Action =
   | { type: 'DISMISS_ERROR' }
   | { type: 'SET_WRITE_STATUS'; status: WriteStatus }
   | { type: 'PUSH_HISTORY'; snapshot: TransactionRow }
-  | { type: 'POP_HISTORY' };
+  | { type: 'POP_HISTORY' }
+  | { type: 'RECEIPT_START' }
+  | { type: 'RECEIPT_PROGRESS'; stage: ReceiptStage }
+  | { type: 'RECEIPT_RESULT'; parsed: ParsedReceipt; suggestion: ReceiptSuggestion }
+  | { type: 'RECEIPT_FAIL'; error: string }
+  | { type: 'RECEIPT_CLOSE' };
 
 export function reducer(state: AppState, action: Action): AppState {
   switch (action.type) {
@@ -64,6 +86,44 @@ export function reducer(state: AppState, action: Action): AppState {
         history: state.history.slice(0, -1),
         index: Math.max(0, state.index - 1),
       };
+
+    case 'RECEIPT_START':
+      return {
+        ...state,
+        mode: 'receipt',
+        receipt: { stage: 'capturing', parsed: null, suggestion: null, error: null },
+      };
+
+    case 'RECEIPT_PROGRESS':
+      if (!state.receipt) return state;
+      return { ...state, receipt: { ...state.receipt, stage: action.stage } };
+
+    case 'RECEIPT_RESULT':
+      return {
+        ...state,
+        mode: 'receipt',
+        receipt: {
+          stage: 'review',
+          parsed: action.parsed,
+          suggestion: action.suggestion,
+          error: null,
+        },
+      };
+
+    case 'RECEIPT_FAIL':
+      return {
+        ...state,
+        mode: 'receipt',
+        receipt: {
+          stage: 'error',
+          parsed: state.receipt?.parsed ?? null,
+          suggestion: state.receipt?.suggestion ?? null,
+          error: action.error,
+        },
+      };
+
+    case 'RECEIPT_CLOSE':
+      return { ...state, mode: 'default', receipt: null };
 
     default:
       return state;

--- a/tests/categories.test.ts
+++ b/tests/categories.test.ts
@@ -5,6 +5,7 @@ import { getMeta, setMeta } from '../src/db/meta.js';
 import {
   getCategories,
   getCategoriesGrouped,
+  getCategoryByName,
   upsertCategories,
   type CategoryRow,
 } from '../src/db/categories.js';
@@ -133,5 +134,42 @@ describe('getCategoriesGrouped', () => {
     const groups = getCategoriesGrouped(db, false);
     expect(groups[0]?.group).toBe('Internal Master Category');
     expect(groups[0]?.categories.map((c) => c.name)).toContain('Inflow: Ready to Assign');
+  });
+});
+
+describe('getCategoryByName', () => {
+  it('returns the matching non-deleted category by exact name', () => {
+    const result = getCategoryByName(db, 'Groceries');
+    expect(result?.id).toBe('c1');
+  });
+
+  it('finds hidden categories', () => {
+    const result = getCategoryByName(db, 'Secret Stash');
+    expect(result?.id).toBe('c4');
+  });
+
+  it('does not return deleted categories', () => {
+    const result = getCategoryByName(db, 'Old Thing');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no category matches', () => {
+    const result = getCategoryByName(db, 'No Such Category');
+    expect(result).toBeNull();
+  });
+
+  it('matches names containing emoji exactly', () => {
+    upsertCategories(db, [
+      {
+        id: 'wc',
+        name: '\u{1F4B5} Wrong Category',
+        group_name: 'Review',
+        hidden: 0,
+        deleted: 0,
+        balance: 0,
+      },
+    ]);
+    const result = getCategoryByName(db, '\u{1F4B5} Wrong Category');
+    expect(result?.id).toBe('wc');
   });
 });

--- a/tests/receipt-parse.test.ts
+++ b/tests/receipt-parse.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { parseReceipt } from '../src/receipt/parse.js';
+
+const TARGET = [
+  'TARGET',
+  'Expect More. Pay Less.',
+  '1234 Main St',
+  '(612) 555-0100',
+  '04/15/2026  14:32',
+  'GROCERY',
+  'MILK 2%        3.99',
+  'BREAD          4.49',
+  'EGGS DOZEN     5.29',
+  'HOUSEHOLD',
+  'DETERGENT      12.99',
+  'PAPER TOWELS   8.99',
+  'SUBTOTAL       35.75',
+  'TAX            2.18',
+  'TOTAL          37.93',
+  'VISA           37.93',
+  'CHANGE         0.00',
+  'THANK YOU',
+];
+
+const COSTCO_SPLIT = [
+  'COSTCO WHOLESALE',
+  '5050 Marketplace Dr',
+  '03-22-26',
+  'ROTISSERIE CHKN',
+  '4.99',
+  'BANANAS ORG',
+  '2.49',
+  'PAPER TOWELS',
+  '21.99',
+  'SUBTOTAL',
+  '29.47',
+  'TAX',
+  '1.80',
+  'GRAND TOTAL',
+  '31.27',
+];
+
+describe('parseReceipt', () => {
+  it('extracts merchant, date, total, and line items from a Target-style receipt', () => {
+    const r = parseReceipt(TARGET);
+    expect(r.merchant).toBe('TARGET');
+    expect(r.date).toBe('2026-04-15');
+    // Total is signed as outflow (negative milliunits).
+    expect(r.total_milliunits).toBe(-37930);
+    expect(r.items.length).toBeGreaterThanOrEqual(5);
+    expect(r.items.find((i) => i.description.startsWith('MILK'))?.amount_milliunits).toBe(-3990);
+    expect(r.items.find((i) => i.description.startsWith('DETERGENT'))?.amount_milliunits).toBe(-12990);
+    // Subtotal/tax/totals must not be folded into items.
+    expect(r.items.some((i) => /SUBTOTAL/i.test(i.description))).toBe(false);
+    expect(r.items.some((i) => /^TAX$/i.test(i.description))).toBe(false);
+    expect(r.items.some((i) => /^TOTAL$/i.test(i.description))).toBe(false);
+  });
+
+  it('reconstructs split-line items where the amount is on its own line', () => {
+    const r = parseReceipt(COSTCO_SPLIT);
+    expect(r.merchant).toBe('COSTCO WHOLESALE');
+    expect(r.date).toBe('2026-03-22');
+    // GRAND TOTAL beats plain TOTAL/SUBTOTAL.
+    expect(r.total_milliunits).toBe(-31270);
+    expect(r.items.find((i) => i.description.startsWith('ROTISSERIE'))?.amount_milliunits).toBe(-4990);
+    expect(r.items.find((i) => i.description.startsWith('BANANAS'))?.amount_milliunits).toBe(-2490);
+    expect(r.items.find((i) => i.description.startsWith('PAPER TOWELS'))?.amount_milliunits).toBe(-21990);
+  });
+
+  it('returns null fields when given empty input', () => {
+    const r = parseReceipt([]);
+    expect(r.merchant).toBeNull();
+    expect(r.date).toBeNull();
+    expect(r.total_milliunits).toBeNull();
+    expect(r.items).toEqual([]);
+  });
+
+  it('skips obvious non-merchant header lines (address, phone, amounts)', () => {
+    const r = parseReceipt([
+      '$5.00',
+      '(555) 555-1212',
+      '999 Elm Avenue',
+      'BOB\'S DINER',
+      'BURGER  9.99',
+      'TOTAL  9.99',
+    ]);
+    expect(r.merchant).toBe("BOB'S DINER");
+  });
+
+  it('falls back to largest bottom-third amount when no total keyword is present', () => {
+    const r = parseReceipt([
+      'CORNER STORE',
+      'CANDY  1.50',
+      'SODA   2.99',
+      'CASH   5.00',
+      '4.49',
+    ]);
+    // No TOTAL/GRAND TOTAL keyword so the bottom-third largest amount wins.
+    // The CASH line is filtered as a payment method, leaving the standalone 4.49.
+    expect(r.total_milliunits).toBe(-4490);
+  });
+
+  it('parses ISO date format too', () => {
+    const r = parseReceipt(['SHOP', '2026-12-31', 'ITEM 1.00', 'TOTAL 1.00']);
+    expect(r.date).toBe('2026-12-31');
+  });
+});

--- a/tests/receipt-suggest.test.ts
+++ b/tests/receipt-suggest.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+import { suggestFromReceipt } from '../src/receipt/suggest.js';
+import type { CategoryRow } from '../src/db/categories.js';
+import type { HistoryRow } from '../src/db/history.js';
+import type { TransactionRow } from '../src/db/transactions.js';
+import type { ParsedReceipt } from '../src/receipt/types.js';
+
+const groceries: CategoryRow = {
+  id: 'cat-grocery',
+  name: 'Groceries',
+  group_name: 'Food',
+  hidden: 0,
+  deleted: 0,
+  balance: 100000,
+};
+
+const household: CategoryRow = {
+  id: 'cat-household',
+  name: 'Household',
+  group_name: 'Home',
+  hidden: 0,
+  deleted: 0,
+  balance: 50000,
+};
+
+const gas: CategoryRow = {
+  id: 'cat-gas',
+  name: 'Gas',
+  group_name: 'Transportation',
+  hidden: 0,
+  deleted: 0,
+  balance: 30000,
+};
+
+const targetTx: TransactionRow = {
+  id: 'tx-1',
+  date: '2026-04-15',
+  amount: -37930, // -$37.93
+  payee_id: 'p-target',
+  payee_name: 'TARGET',
+  category_id: null,
+  category_name: null,
+  memo: null,
+  approved: 0,
+  cleared: 'cleared',
+  account_name: 'Chase',
+  flag_color: null,
+  deleted: 0,
+};
+
+const baseParsed: ParsedReceipt = {
+  merchant: 'TARGET',
+  date: '2026-04-15',
+  total_milliunits: -37930,
+  items: [
+    { description: 'MILK 2%', amount_milliunits: -3990 },
+    { description: 'BREAD', amount_milliunits: -4490 },
+  ],
+  raw_lines: ['TARGET', 'MILK 2% 3.99', 'BREAD 4.49'],
+};
+
+describe('suggestFromReceipt', () => {
+  it('uses payee history as the dominant signal when it is strong', () => {
+    const history: HistoryRow[] = [
+      { payee_id: 'p-target', category_id: 'cat-grocery', count: 26, last_used: '2026-04-01' },
+      { payee_id: 'p-target', category_id: 'cat-household', count: 4, last_used: '2026-03-01' },
+    ];
+    const out = suggestFromReceipt({
+      parsed: baseParsed,
+      transaction: targetTx,
+      categories: [groceries, household, gas],
+      history,
+      keywordMap: [{ keywords: ['detergent'], category: 'Household' }],
+    });
+    expect(out.category_id).toBe('cat-grocery');
+    expect(out.reason.kind).toBe('payee_history');
+    if (out.reason.kind === 'payee_history') {
+      expect(out.reason.pct).toBe(87);
+    }
+    expect(out.merchant_match).toBe('matches');
+    expect(out.date_match).toBe('matches');
+    expect(out.total_mismatch).toBe(false);
+  });
+
+  it('falls back to keyword map when payee history is empty', () => {
+    const out = suggestFromReceipt({
+      parsed: { ...baseParsed, items: [{ description: 'UNLEADED 87', amount_milliunits: -42000 }] },
+      transaction: { ...targetTx, payee_name: 'SHELL', amount: -42000, total_milliunits: -42000 } as TransactionRow,
+      categories: [groceries, household, gas],
+      history: [],
+      keywordMap: [{ keywords: ['unleaded', 'fuel'], category: 'Gas' }],
+    });
+    expect(out.category_id).toBe('cat-gas');
+    expect(out.reason.kind).toBe('keyword');
+    if (out.reason.kind === 'keyword') {
+      expect(out.reason.keyword).toBe('unleaded');
+    }
+  });
+
+  it('falls back to weak payee history when keyword map misses', () => {
+    const history: HistoryRow[] = [
+      { payee_id: 'p-target', category_id: 'cat-grocery', count: 5, last_used: '2026-01-01' },
+      { payee_id: 'p-target', category_id: 'cat-household', count: 5, last_used: '2026-02-01' },
+      { payee_id: 'p-target', category_id: 'cat-gas', count: 4, last_used: '2026-03-01' },
+    ];
+    const out = suggestFromReceipt({
+      parsed: baseParsed,
+      transaction: targetTx,
+      categories: [groceries, household, gas],
+      history,
+      keywordMap: [],
+    });
+    expect(out.category_id).toBe('cat-grocery');
+    expect(out.reason.kind).toBe('payee_history');
+    if (out.reason.kind === 'payee_history') {
+      expect(out.reason.pct).toBeLessThan(50);
+    }
+  });
+
+  it('returns null suggestion when nothing matches', () => {
+    const out = suggestFromReceipt({
+      parsed: { ...baseParsed, merchant: 'UNKNOWN', items: [] },
+      transaction: targetTx,
+      categories: [groceries, household, gas],
+      history: [],
+      keywordMap: [],
+    });
+    expect(out.category_id).toBeNull();
+    expect(out.reason.kind).toBe('none');
+  });
+
+  it('flags total mismatch when receipt total disagrees with tx amount', () => {
+    const out = suggestFromReceipt({
+      parsed: { ...baseParsed, total_milliunits: -50000 },
+      transaction: targetTx,
+      categories: [groceries],
+      history: [
+        { payee_id: 'p-target', category_id: 'cat-grocery', count: 26, last_used: '2026-04-01' },
+      ],
+      keywordMap: [],
+    });
+    expect(out.total_mismatch).toBe(true);
+    expect(out.total_diff_milliunits).toBe(-50000 - -37930);
+  });
+
+  it('matches merchants loosely when store numbers are present', () => {
+    const out = suggestFromReceipt({
+      parsed: { ...baseParsed, merchant: 'TARGET #1847' },
+      transaction: targetTx,
+      categories: [groceries],
+      history: [
+        { payee_id: 'p-target', category_id: 'cat-grocery', count: 10, last_used: '2026-04-01' },
+      ],
+      keywordMap: [],
+    });
+    expect(out.merchant_match).toBe('matches');
+  });
+
+  it('treats dates within 3 days as matching (weekend posting drift)', () => {
+    const out = suggestFromReceipt({
+      parsed: { ...baseParsed, date: '2026-04-13' },
+      transaction: targetTx, // tx date 2026-04-15
+      categories: [groceries],
+      history: [
+        { payee_id: 'p-target', category_id: 'cat-grocery', count: 10, last_used: '2026-04-01' },
+      ],
+      keywordMap: [],
+    });
+    expect(out.date_match).toBe('matches');
+  });
+
+  it('flags differing dates beyond the tolerance window', () => {
+    const out = suggestFromReceipt({
+      parsed: { ...baseParsed, date: '2026-01-01' },
+      transaction: targetTx, // tx date 2026-04-15
+      categories: [groceries],
+      history: [],
+      keywordMap: [],
+    });
+    expect(out.date_match).toBe('differs');
+  });
+});

--- a/tests/tui-snapshots.test.tsx
+++ b/tests/tui-snapshots.test.tsx
@@ -7,9 +7,11 @@ import { WriteStatus } from '../src/tui/WriteStatus.js';
 import { ErrorBanner } from '../src/tui/ErrorBanner.js';
 import { DefaultMode } from '../src/tui/DefaultMode.js';
 import { CategoryPicker } from '../src/tui/CategoryPicker.js';
+import { ReceiptMode } from '../src/tui/ReceiptMode.js';
 import type { TransactionRow } from '../src/db/transactions.js';
 import type { HistoryRow } from '../src/db/history.js';
 import type { CategoryGroup, CategoryRow } from '../src/db/categories.js';
+import type { ReceiptState } from '../src/tui/reducer.js';
 
 const tx: TransactionRow = {
   id: 'tx1',
@@ -144,5 +146,92 @@ describe('TUI snapshots', () => {
       })
     );
     expect(lastFrame()).toContain('No matching categories');
+  });
+
+  it('Footer legend includes the [r] receipt keybind', () => {
+    // The legend is wider than typical narrow terminals so Ink may wrap mid-
+    // label on space; assert each side of the label independently.
+    const { lastFrame } = render(React.createElement(Footer));
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('[r]');
+    expect(frame).toContain('receipt');
+  });
+
+  it('DefaultMode advertises the [r] scan-receipt keybind', () => {
+    const { lastFrame } = render(
+      React.createElement(DefaultMode, {
+        transaction: tx,
+        history,
+        categories,
+        suggestedCategoryName: 'Groceries',
+        writeStatus: 'idle',
+      })
+    );
+    expect(lastFrame()).toContain('[r] scan receipt');
+  });
+
+  it('ReceiptMode renders the capturing-stage spinner', () => {
+    const state: ReceiptState = {
+      stage: 'capturing',
+      parsed: null,
+      suggestion: null,
+      error: null,
+    };
+    const { lastFrame } = render(
+      React.createElement(ReceiptMode, { state, transaction: tx })
+    );
+    expect(lastFrame()).toContain('iPhone capture');
+  });
+
+  it('ReceiptMode renders the review panel with merchant, total, and suggestion', () => {
+    const state: ReceiptState = {
+      stage: 'review',
+      parsed: {
+        merchant: 'TARGET',
+        date: '2026-04-15',
+        total_milliunits: -84220,
+        items: [
+          { description: 'MILK 2%', amount_milliunits: -3990 },
+          { description: 'BREAD', amount_milliunits: -4490 },
+        ],
+        raw_lines: ['TARGET'],
+      },
+      suggestion: {
+        category_id: 'c1',
+        category_name: 'Groceries',
+        reason: { kind: 'payee_history', pct: 64, count: 26 },
+        total_mismatch: false,
+        total_diff_milliunits: 0,
+        merchant_match: 'matches',
+        date_match: 'matches',
+      },
+      error: null,
+    };
+    const { lastFrame } = render(
+      React.createElement(ReceiptMode, { state, transaction: tx })
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('TARGET');
+    expect(frame).toContain('-$84.22');
+    expect(frame).toContain('Suggested:');
+    expect(frame).toContain('Groceries');
+    expect(frame).toContain('payee history');
+    expect(frame).toContain('MILK 2%');
+  });
+
+  it('ReceiptMode renders the error stage with retry hint', () => {
+    const state: ReceiptState = {
+      stage: 'error',
+      parsed: null,
+      suggestion: null,
+      error: 'Shortcut "ynab-blaster-receipt" not found.',
+    };
+    const { lastFrame } = render(
+      React.createElement(ReceiptMode, { state, transaction: tx })
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Receipt scan failed');
+    expect(frame).toContain('not found');
+    expect(frame).toContain('[r] retry');
   });
 });

--- a/tests/tui-snapshots.test.tsx
+++ b/tests/tui-snapshots.test.tsx
@@ -87,6 +87,24 @@ describe('TUI snapshots', () => {
     expect(lastFrame()).toContain('Groceries');
   });
 
+  it('DefaultMode advertises the [w] wrong-category keybind', () => {
+    const { lastFrame } = render(
+      React.createElement(DefaultMode, {
+        transaction: tx,
+        history,
+        categories,
+        suggestedCategoryName: 'Groceries',
+        writeStatus: 'idle',
+      })
+    );
+    expect(lastFrame()).toContain('[w] wrong category');
+  });
+
+  it('Footer legend includes the [w] wrong-category keybind', () => {
+    const { lastFrame } = render(React.createElement(Footer));
+    expect(lastFrame()).toContain('[w] wrong cat');
+  });
+
   it('DefaultMode renders no-history message when history is empty', () => {
     const { lastFrame } = render(
       React.createElement(DefaultMode, {


### PR DESCRIPTION
Closes #16

## Summary

Adds an `[r]` keybind to the blaster TUI that captures a receipt photo via iPhone Continuity Camera, runs local macOS Vision OCR (no cloud, no API key), and surfaces a category suggestion alongside merchant/date/total sanity checks against the current transaction. Nothing is persisted — the image and OCR text are discarded after the user makes a choice.

See issue #16 for the full design context, decision log, and rationale.

## User flow

1. Land on any unapproved transaction in the blaster.
2. Press `r` — Continuity Camera shortcut fires on iPhone.
3. Aim at the receipt; the app progresses through `capturing → ocr → analyzing → review`.
4. Review panel shows merchant, date, total (with ✓/✗ vs the transaction), line items, and a suggested category.
5. Press `y` to approve with the suggestion, `c` to open the category picker, or `esc` to discard.

## First-time setup

```
ynab-blaster install-shortcut
```

Prints step-by-step instructions (or opens a bundled `.shortcut` if one is committed later) for creating the 3-action Shortcuts.app workflow.

## New files

| Path | Purpose |
|---|---|
| `src/native/ocr.swift` | `VNRecognizeTextRequest` wrapper — invoked via `swift script.swift <path>` |
| `src/receipt/types.ts` | Shared interfaces (`ParsedReceipt`, `ReceiptSuggestion`, typed errors) |
| `src/receipt/capture.ts` | Spawns `shortcuts run <name> --output-path`; typed errors for missing/cancelled |
| `src/receipt/ocr.ts` | Spawns the Swift script; actionable error if Xcode CLT not installed |
| `src/receipt/parse.ts` | Pure heuristic parser: merchant from top, line items, date regex, total detection |
| `src/receipt/suggest.ts` | Payee history (≥50%) → keyword map → weak history → null |
| `src/tui/ReceiptMode.tsx` | 5-stage presentational component (capturing/ocr/analyzing/review/error) |
| `src/commands/install-shortcut.ts` | `install-shortcut` subcommand |
| `tests/receipt-parse.test.ts` | 6 parser tests across Target, Costco, and edge-case receipts |
| `tests/receipt-suggest.test.ts` | 8 suggestion tests: history, keyword, fallback, mismatch, match tolerance |

## Modified files

- `reducer.ts` — new `receipt` mode + 5 `RECEIPT_*` actions
- `App.tsx` — `r` keybind, pipeline orchestration, cancel-back-to-receipt from picker
- `Footer.tsx` / `DefaultMode.tsx` — `[r]` hints
- `config.ts` — optional `receipt:` block (defaults to enabled, with starter keyword map)
- `package.json` — postbuild copies `ocr.swift` into `dist/native/`
- `cli.ts` — registers `install-shortcut` subcommand

## Test results

81 tests passing, `tsc --noEmit` clean.