### PR TITLE
feat: Amazon order matching via Python CLI (#17)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Amazon credentials used by `ynab-blaster amazon-sync` and the auto-sync hook.
 # Set these in your shell profile, OR copy this file to ~/.config/ynab-blaster/amazon.env
-# (existing process env always takes precedence over the file).
+# (existing process env always takes precedence over the file). If Amazon blocks
+# direct login with a JavaScript challenge, you can skip these entirely and run
+# `ynab-blaster amazon-login` to create a persisted browser session instead.
 
 AMAZON_USERNAME=your.email@example.com
 AMAZON_PASSWORD=your-amazon-password

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Amazon credentials used by `ynab-blaster amazon-sync` and the auto-sync hook.
+# Set these in your shell profile, OR copy this file to ~/.config/ynab-blaster/amazon.env
+# (existing process env always takes precedence over the file).
+
+AMAZON_USERNAME=your.email@example.com
+AMAZON_PASSWORD=your-amazon-password
+
+# Optional. Required only if your Amazon account has 2FA via authenticator-app TOTP.
+# Use the BASE32 secret you saved when enrolling 2FA (e.g. JBSWY3DPEHPK3PXP).
+# AMAZON_OTP_SECRET_KEY=
+
+# Optional. Override the Python interpreter used to run scripts/amazon_export.py.
+# Defaults to the pipx-managed venv at ~/.local/pipx/venvs/amazon-orders/bin/python.
+# AMAZON_PYTHON=/opt/homebrew/bin/python3.12

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ YNAB Blaster is a terminal CLI tool that lets you rapidly approve, recategorize,
 - **`sync`** — Fetches transactions, categories, and payees from YNAB into a local SQLite database with delta sync (only fetches changes after the first run)
 - **`status`** — Prints unapproved transaction count, inflight writes, and last sync time
 - **`retry-inflight`** — Force-retries any writes that didn't confirm in a previous session (crash recovery)
+- **`amazon-login`** — Opens a real browser window and persists an authenticated Amazon session for future syncs
 - **`amazon-sync`** — Pulls Amazon order history (charges + line items) so the TUI can display matching items inline when you land on an Amazon transaction. Multi-item orders are flagged for split.
 - **Write path with crash safety** — Every write (approve, recategorize, memo, flag) is journaled in `inflight_writes` before the API call. On failure, the local change is rolled back; on crash, the journal survives and can be replayed at startup or via `retry-inflight`
 
@@ -88,6 +89,13 @@ ynab-blaster retry-inflight
 ```
 
 Replays any writes that survived a crash or network failure from a previous session. Safe to run any time — YNAB accepts duplicate PATCHes idempotently.
+### Bootstrap Amazon browser session
+
+```bash
+ynab-blaster amazon-login
+```
+
+Opens a real browser window, waits for you to complete the Amazon sign-in flow, then saves a persisted session cookie jar for future `amazon-sync` runs. This is the most reliable setup when Amazon blocks non-browser logins with a JavaScript challenge.
 
 ### Amazon order matching
 
@@ -106,6 +114,10 @@ export AMAZON_PASSWORD="..."
 # Optional, only if you have authenticator-app 2FA enabled:
 export AMAZON_OTP_SECRET_KEY="JBSWY3DPEHPK3PXP"
 
+#    If Amazon blocks direct logins with a JavaScript challenge, you can skip
+#    the env credentials entirely and bootstrap a browser-backed session instead:
+ynab-blaster amazon-login
+
 # 3. Enable the feature in ~/.config/ynab-blaster/config.yml:
 #    amazon:
 #      enabled: true
@@ -115,7 +127,7 @@ export AMAZON_OTP_SECRET_KEY="JBSWY3DPEHPK3PXP"
 ynab-blaster amazon-sync
 ```
 
-After the first run, `ynab-blaster` (default), `ynab-blaster sync`, and `ynab-blaster amazon-sync` all incrementally re-pull only the days since the last successful sync (auto-sync failures are non-fatal — the TUI still launches with whatever is cached).
+After the first run, `ynab-blaster` (default), `ynab-blaster sync`, and `ynab-blaster amazon-sync` all incrementally re-pull only the days since the last successful sync (auto-sync failures are non-fatal — the TUI still launches with whatever is cached). If direct credential login is blocked, run `ynab-blaster amazon-login` once to persist a browser-backed session, then retry.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ YNAB Blaster is a terminal CLI tool that lets you rapidly approve, recategorize,
 - **`sync`** — Fetches transactions, categories, and payees from YNAB into a local SQLite database with delta sync (only fetches changes after the first run)
 - **`status`** — Prints unapproved transaction count, inflight writes, and last sync time
 - **`retry-inflight`** — Force-retries any writes that didn't confirm in a previous session (crash recovery)
+- **`amazon-sync`** — Pulls Amazon order history (charges + line items) so the TUI can display matching items inline when you land on an Amazon transaction. Multi-item orders are flagged for split.
 - **Write path with crash safety** — Every write (approve, recategorize, memo, flag) is journaled in `inflight_writes` before the API call. On failure, the local change is rolled back; on crash, the journal survives and can be replayed at startup or via `retry-inflight`
 
 ### TUI Keybindings
@@ -88,6 +89,34 @@ ynab-blaster retry-inflight
 
 Replays any writes that survived a crash or network failure from a previous session. Safe to run any time — YNAB accepts duplicate PATCHes idempotently.
 
+### Amazon order matching
+
+When enabled, ynab-blaster shells out to the [`amazon-orders`](https://github.com/alexdlaird/amazon-orders) Python CLI to pull recent Amazon transactions + order line-items into your local DB. The TUI shows matched items inline when you land on an Amazon charge.
+
+#### Setup
+
+```bash
+# 1. Install the Python tool via pipx (use Python 3.12 — pillow wheels lag on 3.13/3.14)
+pipx install --python /opt/homebrew/bin/python3.12 amazon-orders
+
+# 2. Provide credentials. Either export them in your shell, or copy .env.example
+#    to ~/.config/ynab-blaster/amazon.env and fill in the values.
+export AMAZON_USERNAME="you@example.com"
+export AMAZON_PASSWORD="..."
+# Optional, only if you have authenticator-app 2FA enabled:
+export AMAZON_OTP_SECRET_KEY="JBSWY3DPEHPK3PXP"
+
+# 3. Enable the feature in ~/.config/ynab-blaster/config.yml:
+#    amazon:
+#      enabled: true
+#      bootstrap_days: 90
+
+# 4. Bootstrap the local cache (90-day pull on first run):
+ynab-blaster amazon-sync
+```
+
+After the first run, `ynab-blaster` (default), `ynab-blaster sync`, and `ynab-blaster amazon-sync` all incrementally re-pull only the days since the last successful sync (auto-sync failures are non-fatal — the TUI still launches with whatever is cached).
+
 ## Configuration
 
 Config is stored at `~/.config/ynab-blaster/config.yml`:
@@ -98,6 +127,14 @@ budget_id: your-budget-uuid
 db_path: ~/.local/share/ynab-blaster/ynab.db
 include_hidden_categories: false
 sort: date_desc  # date_desc | date_asc | account
+
+# Optional. All keys default to the values shown if omitted.
+amazon:
+  enabled: false             # Set to true after running `pipx install amazon-orders`
+  match_window_days: 7       # +/- N days when pairing a YNAB tx with an Amazon charge
+  bootstrap_days: 90         # Window used on the very first amazon-sync
+  payee_pattern: amazon|amzn # Case-insensitive regex; payees not matching are skipped
+  stale_warning_hours: 24    # Header chip turns yellow after this many hours
 ```
 
 ## Architecture

--- a/scripts/amazon_export.py
+++ b/scripts/amazon_export.py
@@ -80,18 +80,12 @@ def main() -> int:
     parser.add_argument("--skip-orders", action="store_true", help="Skip the orders/items pass (transactions only)")
     args = parser.parse_args()
 
-    username = os.environ.get("AMAZON_USERNAME") or os.environ.get("AMAZON_EMAIL")
-    password = os.environ.get("AMAZON_PASSWORD")
-
-    if not username or not password:
-        print("error: AMAZON_USERNAME (or AMAZON_EMAIL) and AMAZON_PASSWORD must be set in env", file=sys.stderr)
-        return 1
-
     # Map AMAZON_OTP_SECRET → AMAZON_OTP_SECRET_KEY (the env var amazon-orders looks for).
     if os.environ.get("AMAZON_OTP_SECRET") and not os.environ.get("AMAZON_OTP_SECRET_KEY"):
         os.environ["AMAZON_OTP_SECRET_KEY"] = os.environ["AMAZON_OTP_SECRET"]
 
     try:
+        from amazonorders.exception import AmazonOrdersAuthError, AmazonOrdersAuthRedirectError, AmazonOrdersError
         from amazonorders.session import AmazonSession
         from amazonorders.orders import AmazonOrders
         from amazonorders.transactions import AmazonTransactions
@@ -99,30 +93,66 @@ def main() -> int:
         print(f"error: amazon-orders not installed in this Python env: {e}", file=sys.stderr)
         print("Install with: pipx install amazon-orders --python /opt/homebrew/bin/python3.12", file=sys.stderr)
         return 2
+    username = os.environ.get("AMAZON_USERNAME") or os.environ.get("AMAZON_EMAIL")
+    password = os.environ.get("AMAZON_PASSWORD")
 
-    print("Logging in to Amazon...", file=sys.stderr)
-    session = AmazonSession(username, password)
-    session.login()
+    try:
+        session = AmazonSession(username, password)
+        if session.auth_cookies_stored():
+            print("Using persisted Amazon session...", file=sys.stderr)
+            session.is_authenticated = True
+        else:
+            if not username or not password:
+                print(
+                    "error: no persisted Amazon session found. Either set AMAZON_USERNAME (or AMAZON_EMAIL) and AMAZON_PASSWORD, "
+                    "or run `ynab-blaster amazon-login` to create a browser-backed session.",
+                    file=sys.stderr,
+                )
+                return 1
 
-    print(f"Fetching transactions (last {args.days} days)...", file=sys.stderr)
-    txns = AmazonTransactions(session)
-    transactions_out: list[dict[str, Any]] = []
-    for t in txns.get_transactions(days=args.days):
-        transactions_out.append(_serialize_transaction(t))
+            print("Logging in to Amazon...", file=sys.stderr)
+            session.login()
 
-    orders_out: list[dict[str, Any]] = []
-    if not args.skip_orders:
-        time_filter = _resolve_time_filter(args.days)
-        print(f"Fetching orders (time_filter={time_filter})...", file=sys.stderr)
-        orders_api = AmazonOrders(session)
-        for o in orders_api.get_order_history(time_filter=time_filter, full_details=False):
-            orders_out.append(_serialize_order(o))
+        print(f"Fetching transactions (last {args.days} days)...", file=sys.stderr)
+        txns = AmazonTransactions(session)
+        transactions_out: list[dict[str, Any]] = []
+        for t in txns.get_transactions(days=args.days):
+            transactions_out.append(_serialize_transaction(t))
 
-    print(json.dumps({
-        "transactions": transactions_out,
-        "orders": orders_out,
-    }))
-    return 0
+        orders_out: list[dict[str, Any]] = []
+        if not args.skip_orders:
+            time_filter = _resolve_time_filter(args.days)
+            print(f"Fetching orders (time_filter={time_filter})...", file=sys.stderr)
+            orders_api = AmazonOrders(session)
+            for o in orders_api.get_order_history(time_filter=time_filter, full_details=False):
+                orders_out.append(_serialize_order(o))
+
+        print(json.dumps({
+            "transactions": transactions_out,
+            "orders": orders_out,
+        }))
+        return 0
+    except AmazonOrdersAuthRedirectError:
+        print(
+            "error: persisted Amazon session expired or was rejected by Amazon. "
+            "Run `ynab-blaster amazon-login` to refresh it, then retry.",
+            file=sys.stderr,
+        )
+        return 1
+    except AmazonOrdersAuthError as e:
+        message = str(e)
+        if "JavaScript-based authentication challenge page" in message:
+            print(
+                "error: Amazon blocked the direct login flow with a JavaScript challenge. "
+                "Run `ynab-blaster amazon-login` to sign in through a real browser and persist a session, then retry `ynab-blaster amazon-sync`.",
+                file=sys.stderr,
+            )
+        else:
+            print(f"error: {message}", file=sys.stderr)
+        return 1
+    except AmazonOrdersError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/scripts/amazon_export.py
+++ b/scripts/amazon_export.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+amazon_export.py — bridge between ynab-blaster (Node) and amazon-orders (Python).
+
+Reads Amazon credentials from env (AMAZON_USERNAME / AMAZON_PASSWORD,
+optionally AMAZON_OTP_SECRET_KEY), pulls Transactions + Orders via the
+amazonorders Python API, and emits a single JSON object on stdout.
+
+Stdout: JSON
+Stderr: progress / errors (human-readable)
+Exit code: 0 on success, non-zero on auth or scrape failure
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+
+def _amount_to_milliunits(amount: float, is_refund: bool) -> int:
+    """
+    Convert a transaction grand_total to YNAB-style signed milliunits.
+
+    YNAB convention: outflows are negative, inflows (refunds) are positive.
+    The amazon-orders library sometimes returns charges as negative grand_total
+    and refunds as positive (with is_refund=True), but to be defensive we
+    derive the sign from the is_refund flag rather than trusting the input sign.
+    """
+    abs_milliunits = round(abs(float(amount)) * 1000)
+    return abs_milliunits if is_refund else -abs_milliunits
+
+
+def _serialize_transaction(t: Any) -> dict[str, Any]:
+    return {
+        "order_number": t.order_number,
+        "completed_date": t.completed_date.isoformat() if t.completed_date else None,
+        "grand_total": float(t.grand_total) if t.grand_total is not None else 0.0,
+        "is_refund": bool(t.is_refund),
+        "milliunits": _amount_to_milliunits(t.grand_total, t.is_refund) if t.grand_total is not None else 0,
+        "payment_method": t.payment_method,
+        "seller": t.seller,
+    }
+
+
+def _serialize_order(o: Any) -> dict[str, Any]:
+    items = []
+    for item in (o.items or []):
+        items.append({
+            "title": item.title or "",
+            "price": float(item.price) if item.price is not None else None,
+            "quantity": int(item.quantity) if item.quantity is not None else 1,
+        })
+    return {
+        "order_number": o.order_number,
+        "order_placed_date": o.order_placed_date.isoformat() if o.order_placed_date else None,
+        "grand_total": float(o.grand_total) if o.grand_total is not None else None,
+        "items": items,
+    }
+
+
+def _resolve_time_filter(days: int) -> str:
+    """
+    Map a days-window to the closest amazon-orders time_filter.
+    The library only exposes preset filters: last30 / months-3 / year=N.
+    For days > 90 we fall back to months-3 (callers will see a warning).
+    """
+    if days <= 30:
+        return "last30"
+    if days <= 90:
+        return "months-3"
+    return "months-3"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export Amazon transactions + orders as JSON")
+    parser.add_argument("--days", type=int, default=30, help="Window of days for transactions (default 30)")
+    parser.add_argument("--skip-orders", action="store_true", help="Skip the orders/items pass (transactions only)")
+    args = parser.parse_args()
+
+    username = os.environ.get("AMAZON_USERNAME") or os.environ.get("AMAZON_EMAIL")
+    password = os.environ.get("AMAZON_PASSWORD")
+
+    if not username or not password:
+        print("error: AMAZON_USERNAME (or AMAZON_EMAIL) and AMAZON_PASSWORD must be set in env", file=sys.stderr)
+        return 1
+
+    # Map AMAZON_OTP_SECRET → AMAZON_OTP_SECRET_KEY (the env var amazon-orders looks for).
+    if os.environ.get("AMAZON_OTP_SECRET") and not os.environ.get("AMAZON_OTP_SECRET_KEY"):
+        os.environ["AMAZON_OTP_SECRET_KEY"] = os.environ["AMAZON_OTP_SECRET"]
+
+    try:
+        from amazonorders.session import AmazonSession
+        from amazonorders.orders import AmazonOrders
+        from amazonorders.transactions import AmazonTransactions
+    except ImportError as e:
+        print(f"error: amazon-orders not installed in this Python env: {e}", file=sys.stderr)
+        print("Install with: pipx install amazon-orders --python /opt/homebrew/bin/python3.12", file=sys.stderr)
+        return 2
+
+    print("Logging in to Amazon...", file=sys.stderr)
+    session = AmazonSession(username, password)
+    session.login()
+
+    print(f"Fetching transactions (last {args.days} days)...", file=sys.stderr)
+    txns = AmazonTransactions(session)
+    transactions_out: list[dict[str, Any]] = []
+    for t in txns.get_transactions(days=args.days):
+        transactions_out.append(_serialize_transaction(t))
+
+    orders_out: list[dict[str, Any]] = []
+    if not args.skip_orders:
+        time_filter = _resolve_time_filter(args.days)
+        print(f"Fetching orders (time_filter={time_filter})...", file=sys.stderr)
+        orders_api = AmazonOrders(session)
+        for o in orders_api.get_order_history(time_filter=time_filter, full_details=False):
+            orders_out.append(_serialize_order(o))
+
+    print(json.dumps({
+        "transactions": transactions_out,
+        "orders": orders_out,
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/amazon/browser-auth.ts
+++ b/src/amazon/browser-auth.ts
@@ -1,0 +1,259 @@
+import { mkdirSync, writeFileSync, existsSync } from 'fs';
+import { spawn, type ChildProcess } from 'child_process';
+import { createServer } from 'net';
+import { dirname, join } from 'path';
+import { setTimeout as delay } from 'timers/promises';
+import {
+  getAmazonBrowserProfileDir,
+  getAmazonOrdersCookieJarPath,
+  getAmazonSignInUrl,
+} from './client.js';
+
+interface DevToolsTarget {
+  type: string;
+  url: string;
+  webSocketDebuggerUrl?: string;
+}
+
+interface CDPCookie {
+  name: string;
+  value: string;
+  domain: string;
+}
+
+interface CDPResult<T> {
+  id?: number;
+  result?: T;
+  error?: { message?: string };
+}
+
+const MAC_BROWSER_CANDIDATES = [
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
+  '/Applications/Chromium.app/Contents/MacOS/Chromium',
+  '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+  '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+];
+
+const LINUX_BROWSER_CANDIDATES = [
+  '/usr/bin/google-chrome',
+  '/usr/bin/google-chrome-stable',
+  '/usr/bin/chromium',
+  '/usr/bin/chromium-browser',
+  '/usr/bin/brave-browser',
+  '/snap/bin/chromium',
+];
+
+function browserCandidates(): string[] {
+  if (process.platform === 'darwin') return MAC_BROWSER_CANDIDATES;
+  if (process.platform === 'linux') return LINUX_BROWSER_CANDIDATES;
+  return [];
+}
+
+export function findBrowserExecutable(): string {
+  const envOverride = process.env.AMAZON_BROWSER;
+  if (envOverride) {
+    if (existsSync(envOverride)) return envOverride;
+    throw new Error(`AMAZON_BROWSER is set but does not exist: ${envOverride}`);
+  }
+
+  const match = browserCandidates().find((c) => existsSync(c));
+  if (match) return match;
+
+  throw new Error(
+    'No supported Chromium-based browser was found. Install Chrome/Chromium/Brave, or set AMAZON_BROWSER to the browser executable path.'
+  );
+}
+
+async function allocatePort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Failed to allocate a local debugging port.'));
+        return;
+      }
+      const { port } = address;
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve(port);
+      });
+    });
+  });
+}
+
+async function fetchTargets(port: number): Promise<DevToolsTarget[]> {
+  const response = await fetch(`http://127.0.0.1:${port}/json/list`);
+  if (!response.ok) throw new Error(`DevTools endpoint returned ${response.status}`);
+  return (await response.json()) as DevToolsTarget[];
+}
+
+async function waitForTargetWebSocketUrl(
+  port: number,
+  browserProcess: ChildProcess,
+  timeoutMs: number
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    if (browserProcess.exitCode !== null) {
+      throw new Error('Browser exited before the remote debugging endpoint became available.');
+    }
+    try {
+      const targets = await fetchTargets(port);
+      const target =
+        targets.find((t) => t.type === 'page' && t.url.includes('amazon.com')) ??
+        targets.find((t) => t.type === 'page');
+      if (target?.webSocketDebuggerUrl) return target.webSocketDebuggerUrl;
+    } catch (err) {
+      lastError = err;
+    }
+    await delay(250);
+  }
+
+  throw new Error(
+    `Timed out waiting for browser debugging endpoint: ${lastError instanceof Error ? lastError.message : 'unknown error'}`
+  );
+}
+
+function messageDataToString(data: unknown): string {
+  if (typeof data === 'string') return data;
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString('utf8');
+  if (ArrayBuffer.isView(data))
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString('utf8');
+  throw new Error('Received an unsupported WebSocket message payload type.');
+}
+
+class CDPSession {
+  private nextId = 1;
+  private readonly pending = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (error: Error) => void }
+  >();
+
+  private constructor(private readonly socket: WebSocket) {
+    this.socket.addEventListener('message', (event) => {
+      const message = JSON.parse(messageDataToString(event.data)) as CDPResult<unknown>;
+      if (typeof message.id !== 'number') return;
+
+      const entry = this.pending.get(message.id);
+      if (!entry) return;
+      this.pending.delete(message.id);
+
+      if (message.error?.message) entry.reject(new Error(message.error.message));
+      else entry.resolve(message.result);
+    });
+
+    const rejectAll = (reason: string) => {
+      for (const { reject } of this.pending.values()) reject(new Error(reason));
+      this.pending.clear();
+    };
+    this.socket.addEventListener('close', () => rejectAll('Browser debugging session closed.'));
+    this.socket.addEventListener('error', () => rejectAll('Browser debugging session errored.'));
+  }
+
+  static async connect(url: string): Promise<CDPSession> {
+    const socket = new WebSocket(url);
+    await new Promise<void>((resolve, reject) => {
+      socket.addEventListener('open', () => resolve(), { once: true });
+      socket.addEventListener(
+        'error',
+        () => reject(new Error('Failed to connect to browser debugging session.')),
+        { once: true }
+      );
+    });
+    return new CDPSession(socket);
+  }
+
+  async send<T>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+    const id = this.nextId++;
+    return await new Promise<T>((resolve, reject) => {
+      this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject });
+      this.socket.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  close(): void {
+    this.socket.close();
+  }
+}
+
+async function waitForAuthenticatedCookies(
+  session: CDPSession,
+  browserProcess: ChildProcess,
+  timeoutMs: number
+): Promise<Record<string, string>> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (browserProcess.exitCode !== null)
+      throw new Error('Browser was closed before an authenticated Amazon session was detected.');
+
+    const { cookies } = await session.send<{ cookies: CDPCookie[] }>('Network.getAllCookies');
+    const amazonCookies = cookies
+      .filter((c) => c.domain.includes('amazon.com') && c.value)
+      .sort((a, b) => a.domain.length - b.domain.length);
+
+    if (amazonCookies.some((c) => c.name === 'x-main')) {
+      return Object.fromEntries(amazonCookies.map((c) => [c.name, c.value]));
+    }
+    await delay(1000);
+  }
+
+  throw new Error(
+    'Timed out waiting for an authenticated Amazon session. Complete sign-in in the browser window and leave it open until the terminal reports success.'
+  );
+}
+
+async function stopBrowser(proc: ChildProcess): Promise<void> {
+  if (proc.exitCode !== null) return;
+  proc.kill('SIGTERM');
+  const deadline = Date.now() + 5000;
+  while (proc.exitCode === null && Date.now() < deadline) await delay(100);
+  if (proc.exitCode === null) proc.kill('SIGKILL');
+}
+
+// Opens a real browser, waits for the user to complete Amazon login, then
+// saves the resulting cookies to the amazon-orders cookie jar so subsequent
+// `amazon-sync` runs use a pre-authenticated session.
+export async function bootstrapAmazonSessionInBrowser(): Promise<string> {
+  const executablePath = findBrowserExecutable();
+  const port = await allocatePort();
+  const profileDir = getAmazonBrowserProfileDir();
+  const cookieJarPath = getAmazonOrdersCookieJarPath();
+
+  mkdirSync(profileDir, { recursive: true });
+  mkdirSync(dirname(cookieJarPath), { recursive: true });
+
+  const browserProcess = spawn(
+    executablePath,
+    [
+      `--remote-debugging-port=${port}`,
+      `--user-data-dir=${profileDir}`,
+      '--new-window',
+      '--no-first-run',
+      '--no-default-browser-check',
+      getAmazonSignInUrl(),
+    ],
+    { stdio: 'ignore' }
+  );
+
+  let session: CDPSession | null = null;
+  try {
+    const wsUrl = await waitForTargetWebSocketUrl(port, browserProcess, 30_000);
+    session = await CDPSession.connect(wsUrl);
+    await session.send('Network.enable');
+
+    const cookieJar = await waitForAuthenticatedCookies(session, browserProcess, 10 * 60 * 1000);
+    writeFileSync(cookieJarPath, JSON.stringify(cookieJar));
+    return cookieJarPath;
+  } finally {
+    session?.close();
+    await stopBrowser(browserProcess);
+  }
+}

--- a/src/amazon/client.ts
+++ b/src/amazon/client.ts
@@ -1,0 +1,75 @@
+import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { execFileSync } from 'child_process';
+
+const CONFIG_DIR = join(homedir(), '.config', 'ynab-blaster');
+const ENV_FILE = join(CONFIG_DIR, 'amazon.env');
+
+// __dirname equivalent for ESM. Resolves to dist/amazon/ at runtime;
+// scripts/ lives next to dist/, so we go up two levels.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = join(HERE, '..', '..', 'scripts', 'amazon_export.py');
+
+// Loads AMAZON_USERNAME, AMAZON_EMAIL, AMAZON_PASSWORD, AMAZON_OTP_SECRET[_KEY]
+// from the optional amazon.env file. Existing env values take precedence.
+export function loadAmazonEnv(): void {
+  if (!existsSync(ENV_FILE)) return;
+  const lines = readFileSync(ENV_FILE, 'utf8').split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx < 1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const value = trimmed.slice(eqIdx + 1).trim();
+    if (!process.env[key]) process.env[key] = value;
+  }
+}
+
+// Returns true if either AMAZON_USERNAME or AMAZON_EMAIL plus AMAZON_PASSWORD are set.
+export function hasAmazonCreds(): boolean {
+  const user = process.env.AMAZON_USERNAME ?? process.env.AMAZON_EMAIL;
+  return !!(user && process.env.AMAZON_PASSWORD);
+}
+
+// Common locations to probe for the amazon-orders pipx venv Python.
+// We prefer the pipx-managed Python because users typically install with:
+//   pipx install --python /opt/homebrew/bin/python3.12 amazon-orders
+// and that venv has the package available.
+const PIPX_VENV_CANDIDATES: string[] = [
+  join(homedir(), '.local', 'pipx', 'venvs', 'amazon-orders', 'bin', 'python'),
+];
+
+// Resolves the Python interpreter to use for running the export script.
+// Order:
+//   1. AMAZON_PYTHON env var (explicit override)
+//   2. pipx venv for amazon-orders (most users install this way)
+//   3. python3 / python on PATH (works only if amazon-orders is globally installed)
+export function resolvePython(): string {
+  if (process.env.AMAZON_PYTHON && existsSync(process.env.AMAZON_PYTHON)) {
+    return process.env.AMAZON_PYTHON;
+  }
+  for (const candidate of PIPX_VENV_CANDIDATES) {
+    if (existsSync(candidate)) return candidate;
+  }
+  // Last-resort PATH lookup. We use `which` instead of trying to spawn each
+  // interpreter so a missing one fails fast.
+  for (const cmd of ['python3', 'python']) {
+    try {
+      const path = execFileSync('which', [cmd], { encoding: 'utf8' }).trim();
+      if (path) return path;
+    } catch {
+      /* not on PATH */
+    }
+  }
+  throw new Error(
+    'No Python interpreter found. Install amazon-orders via pipx, or set AMAZON_PYTHON to a Python path.'
+  );
+}
+
+// Returns the absolute filesystem path to scripts/amazon_export.py.
+export function getExportScriptPath(): string {
+  return SCRIPT_PATH;
+}

--- a/src/amazon/client.ts
+++ b/src/amazon/client.ts
@@ -6,6 +6,18 @@ import { execFileSync } from 'child_process';
 
 const CONFIG_DIR = join(homedir(), '.config', 'ynab-blaster');
 const ENV_FILE = join(CONFIG_DIR, 'amazon.env');
+const AMAZON_ORDERS_CONFIG_DIR = join(homedir(), '.config', 'amazonorders');
+const AMAZON_ORDERS_COOKIE_JAR = join(AMAZON_ORDERS_CONFIG_DIR, 'cookies.json');
+const AMAZON_BROWSER_PROFILE_DIR = join(CONFIG_DIR, 'amazon-browser-profile');
+const AMAZON_SIGN_IN_URL = `https://www.amazon.com/ap/signin?${new URLSearchParams({
+  'openid.pape.max_auth_age': '0',
+  'openid.return_to': 'https://www.amazon.com/?ref_=nav_custrec_signin',
+  'openid.identity': 'http://specs.openid.net/auth/2.0/identifier_select',
+  'openid.assoc_handle': 'usflex',
+  'openid.mode': 'checkid_setup',
+  'openid.claimed_id': 'http://specs.openid.net/auth/2.0/identifier_select',
+  'openid.ns': 'http://specs.openid.net/auth/2.0',
+}).toString()}`;
 
 // __dirname equivalent for ESM. Resolves to dist/amazon/ at runtime;
 // scripts/ lives next to dist/, so we go up two levels.
@@ -32,6 +44,24 @@ export function loadAmazonEnv(): void {
 export function hasAmazonCreds(): boolean {
   const user = process.env.AMAZON_USERNAME ?? process.env.AMAZON_EMAIL;
   return !!(user && process.env.AMAZON_PASSWORD);
+}
+
+// Returns true if the amazon-orders cookie jar exists and appears to contain
+// an authenticated Amazon session cookie.
+export function hasPersistedAmazonSession(): boolean {
+  if (!existsSync(AMAZON_ORDERS_COOKIE_JAR)) return false;
+  try {
+    const raw = JSON.parse(readFileSync(AMAZON_ORDERS_COOKIE_JAR, 'utf8')) as Record<string, unknown>;
+    return typeof raw['x-main'] === 'string' && raw['x-main'].length > 0;
+  } catch {
+    return false;
+  }
+}
+
+// Returns true if Amazon auth is available via env credentials OR a persisted
+// cookie jar produced by amazon-orders / `ynab-blaster amazon-login`.
+export function hasAmazonAuthAvailable(): boolean {
+  return hasAmazonCreds() || hasPersistedAmazonSession();
 }
 
 // Common locations to probe for the amazon-orders pipx venv Python.
@@ -72,4 +102,20 @@ export function resolvePython(): string {
 // Returns the absolute filesystem path to scripts/amazon_export.py.
 export function getExportScriptPath(): string {
   return SCRIPT_PATH;
+}
+
+// Returns the absolute path to the cookie jar `amazon-orders` reads on startup.
+export function getAmazonOrdersCookieJarPath(): string {
+  return AMAZON_ORDERS_COOKIE_JAR;
+}
+
+// Returns the directory used for the dedicated browser profile during
+// `ynab-blaster amazon-login`.
+export function getAmazonBrowserProfileDir(): string {
+  return AMAZON_BROWSER_PROFILE_DIR;
+}
+
+// Returns the Amazon sign-in URL used by the browser bootstrap flow.
+export function getAmazonSignInUrl(): string {
+  return AMAZON_SIGN_IN_URL;
 }

--- a/src/amazon/match.ts
+++ b/src/amazon/match.ts
@@ -1,0 +1,45 @@
+import type Database from 'better-sqlite3';
+import type { TransactionRow } from '../db/transactions.js';
+import { getAmazonItems, type AmazonChargeRow } from '../db/amazon.js';
+import type { AmazonConfig } from '../config.js';
+import type { AmazonMatch } from './types.js';
+
+// Finds the best Amazon charge match for a YNAB transaction.
+// Returns null when matching is disabled, the payee isn't Amazon-like,
+// or no charge with the same amount lies within the configured date window.
+export function findAmazonMatch(
+  tx: TransactionRow,
+  db: Database.Database,
+  config: AmazonConfig
+): AmazonMatch | null {
+  if (!config.enabled) return null;
+
+  // Skip inflows — refunds are out of scope for v1.
+  if (tx.amount > 0) return null;
+
+  // Only consider Amazon-like payees.
+  if (!tx.payee_name || !new RegExp(config.payee_pattern, 'i').test(tx.payee_name)) {
+    return null;
+  }
+
+  const matches = db
+    .prepare(
+      `SELECT * FROM amazon_charges
+       WHERE total_milliunits = ?
+         AND completed_date BETWEEN date(?, ?) AND date(?, ?)
+       ORDER BY ABS(julianday(completed_date) - julianday(?)) ASC`
+    )
+    .all(
+      tx.amount,
+      tx.date, `-${config.match_window_days} days`,
+      tx.date, `+${config.match_window_days} days`,
+      tx.date
+    ) as AmazonChargeRow[];
+
+  if (matches.length === 0) return null;
+
+  const charge = matches[0];
+  const items = getAmazonItems(db, charge.order_number);
+
+  return { charge, items, ambiguous: matches.length > 1 };
+}

--- a/src/amazon/sync.ts
+++ b/src/amazon/sync.ts
@@ -1,0 +1,144 @@
+import { spawn } from 'child_process';
+import type Database from 'better-sqlite3';
+import { setMeta } from '../db/meta.js';
+import {
+  upsertAmazonCharges,
+  upsertAmazonItems,
+  getLatestAmazonChargeDate,
+  type AmazonChargeRow,
+  type AmazonItemRow,
+} from '../db/amazon.js';
+import {
+  loadAmazonEnv,
+  hasAmazonCreds,
+  resolvePython,
+  getExportScriptPath,
+} from './client.js';
+import type { AmazonConfig } from '../config.js';
+import type { AmazonSyncResult, ExportPayload } from './types.js';
+
+// Runs scripts/amazon_export.py as a subprocess and returns its parsed JSON output.
+// Inherits stderr so progress messages appear in the parent terminal.
+async function runExport(days: number): Promise<ExportPayload> {
+  const python = resolvePython();
+  const script = getExportScriptPath();
+
+  return await new Promise<ExportPayload>((resolve, reject) => {
+    const child = spawn(python, [script, '--days', String(days)], {
+      // Forward env so the script can read AMAZON_USERNAME / AMAZON_PASSWORD.
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+
+    let stdout = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
+    });
+
+    child.on('error', (err) => reject(err));
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`amazon_export.py exited with code ${code}`));
+        return;
+      }
+      try {
+        resolve(JSON.parse(stdout) as ExportPayload);
+      } catch (e) {
+        reject(new Error(`failed to parse amazon_export.py output as JSON: ${(e as Error).message}`));
+      }
+    });
+  });
+}
+
+// Decides how many days back to sync.
+// Override wins; otherwise: incremental from latest charge date (with 2d buffer)
+// OR bootstrap_days when the table is empty.
+function resolveDaysWindow(
+  db: Database.Database,
+  config: AmazonConfig,
+  overrideDays?: number
+): number {
+  if (overrideDays !== undefined) return overrideDays;
+
+  const latest = getLatestAmazonChargeDate(db);
+  if (!latest) return config.bootstrap_days;
+
+  const latestMs = new Date(latest + 'T00:00:00').getTime();
+  const todayMs = Date.now();
+  const daysSinceLatest = Math.ceil((todayMs - latestMs) / (24 * 60 * 60 * 1000));
+  // 2-day buffer covers late-finalized transactions / clock skew.
+  return Math.max(daysSinceLatest + 2, 1);
+}
+
+// Pulls Amazon transactions + orders via the Python helper and persists them.
+export async function runAmazonSync(
+  db: Database.Database,
+  config: AmazonConfig,
+  opts: { overrideDays?: number } = {}
+): Promise<AmazonSyncResult> {
+  const days = resolveDaysWindow(db, config, opts.overrideDays);
+  const now = new Date().toISOString();
+
+  setMeta(db, 'amazon_last_attempt', now);
+
+  const payload = await runExport(days);
+
+  const charges: AmazonChargeRow[] = payload.transactions
+    .filter((t) => t.completed_date != null)
+    .map((t) => ({
+      order_number: t.order_number,
+      completed_date: t.completed_date as string,
+      total_milliunits: t.milliunits,
+      is_refund: t.is_refund ? 1 : 0,
+      payment_method: t.payment_method ?? null,
+      seller: t.seller ?? null,
+      raw_json: JSON.stringify(t),
+      fetched_at: now,
+    }));
+
+  const items: Omit<AmazonItemRow, 'id'>[] = [];
+  for (const order of payload.orders) {
+    for (const item of order.items) {
+      items.push({
+        order_number: order.order_number,
+        title: item.title,
+        quantity: item.quantity,
+        price_milliunits: item.price != null ? Math.round(item.price * 1000) : null,
+      });
+    }
+  }
+
+  upsertAmazonCharges(db, charges);
+  upsertAmazonItems(db, items);
+
+  setMeta(db, 'amazon_last_success', now);
+  setMeta(db, 'amazon_last_error', '');
+
+  return { chargesAdded: charges.length, itemsAdded: items.length, daysWindow: days };
+}
+
+// Non-fatal variant for the auto-sync path. Logs warnings, never throws.
+export async function runAmazonSyncSafe(
+  db: Database.Database,
+  config: AmazonConfig
+): Promise<AmazonSyncResult | null> {
+  loadAmazonEnv();
+  if (!config.enabled || !hasAmazonCreds()) return null;
+
+  try {
+    return await runAmazonSync(db, config);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const now = new Date().toISOString();
+    try {
+      setMeta(db, 'amazon_last_error', message);
+      setMeta(db, 'amazon_last_attempt', now);
+    } catch {
+      /* DB may be broken too; stay non-fatal. */
+    }
+    process.stderr.write(
+      `[amazon-sync] failed: ${message}. Continuing with existing data.\n`
+    );
+    return null;
+  }
+}

--- a/src/amazon/sync.ts
+++ b/src/amazon/sync.ts
@@ -10,7 +10,7 @@ import {
 } from '../db/amazon.js';
 import {
   loadAmazonEnv,
-  hasAmazonCreds,
+  hasAmazonAuthAvailable,
   resolvePython,
   getExportScriptPath,
 } from './client.js';
@@ -27,18 +27,31 @@ async function runExport(days: number): Promise<ExportPayload> {
     const child = spawn(python, [script, '--days', String(days)], {
       // Forward env so the script can read AMAZON_USERNAME / AMAZON_PASSWORD.
       env: process.env,
-      stdio: ['ignore', 'pipe', 'inherit'],
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
 
     let stdout = '';
+    let stderr = '';
     child.stdout.on('data', (chunk: Buffer) => {
       stdout += chunk.toString('utf8');
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      const text = chunk.toString('utf8');
+      stderr += text;
+      process.stderr.write(text);
     });
 
     child.on('error', (err) => reject(err));
     child.on('close', (code) => {
       if (code !== 0) {
-        reject(new Error(`amazon_export.py exited with code ${code}`));
+        const detail = stderr.trim();
+        reject(
+          new Error(
+            detail
+              ? `amazon_export.py exited with code ${code}: ${detail}`
+              : `amazon_export.py exited with code ${code}`
+          )
+        );
         return;
       }
       try {
@@ -123,7 +136,7 @@ export async function runAmazonSyncSafe(
   config: AmazonConfig
 ): Promise<AmazonSyncResult | null> {
   loadAmazonEnv();
-  if (!config.enabled || !hasAmazonCreds()) return null;
+  if (!config.enabled || !hasAmazonAuthAvailable()) return null;
 
   try {
     return await runAmazonSync(db, config);

--- a/src/amazon/types.ts
+++ b/src/amazon/types.ts
@@ -1,0 +1,36 @@
+import type { AmazonChargeRow, AmazonItemRow } from '../db/amazon.js';
+
+export interface AmazonMatch {
+  charge: AmazonChargeRow;
+  items: AmazonItemRow[];
+  ambiguous: boolean;
+}
+
+export interface AmazonSyncResult {
+  chargesAdded: number;
+  itemsAdded: number;
+  daysWindow: number;
+}
+
+// Shape of the JSON emitted by scripts/amazon_export.py
+export interface ExportPayload {
+  transactions: Array<{
+    order_number: string;
+    completed_date: string | null;
+    grand_total: number;
+    is_refund: boolean;
+    milliunits: number;
+    payment_method: string | null;
+    seller: string | null;
+  }>;
+  orders: Array<{
+    order_number: string;
+    order_placed_date: string | null;
+    grand_total: number | null;
+    items: Array<{
+      title: string;
+      price: number | null;
+      quantity: number;
+    }>;
+  }>;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,14 @@ program
   });
 
 program
+  .command('amazon-login')
+  .description('Open a browser and persist an authenticated Amazon session for amazon-sync')
+  .action(async () => {
+    const { runAmazonLoginCommand } = await import('./commands/amazon-login.js');
+    await runAmazonLoginCommand();
+  });
+
+program
   .command('amazon-sync')
   .description('Sync Amazon order history (uses bootstrap window on first run)')
   .option('--days <n>', 'Override sync window to the last N days', (v) => parseInt(v, 10))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,15 @@ program
     await runRetryInflight();
   });
 
+program
+  .command('amazon-sync')
+  .description('Sync Amazon order history (uses bootstrap window on first run)')
+  .option('--days <n>', 'Override sync window to the last N days', (v) => parseInt(v, 10))
+  .action(async (opts: { days?: number }) => {
+    const { runAmazonSyncCommand } = await import('./commands/amazon-sync.js');
+    await runAmazonSyncCommand(opts);
+  });
+
 // Default command (no subcommand) — runs the TUI blaster.
 program
   .command('run', { isDefault: true, hidden: true })

--- a/src/commands/amazon-login.ts
+++ b/src/commands/amazon-login.ts
@@ -1,0 +1,16 @@
+import { bootstrapAmazonSessionInBrowser } from '../amazon/browser-auth.js';
+
+// `ynab-blaster amazon-login` — opens a real browser, waits for the user to
+// finish Amazon sign-in, then saves the resulting authenticated cookies for
+// future amazon-sync runs.
+export async function runAmazonLoginCommand(): Promise<void> {
+  console.log('Opening a browser window for Amazon sign-in...');
+  console.log(
+    'Complete the login flow in the browser. This command will continue automatically once an authenticated session is detected.'
+  );
+
+  const cookieJarPath = await bootstrapAmazonSessionInBrowser();
+
+  console.log('Amazon session saved.');
+  console.log(`  Cookie jar: ${cookieJarPath}`);
+}

--- a/src/commands/amazon-sync.ts
+++ b/src/commands/amazon-sync.ts
@@ -1,0 +1,31 @@
+import { loadConfig } from '../config.js';
+import { openDatabase } from '../db/client.js';
+import { applySchema } from '../db/schema.js';
+import { loadAmazonEnv, hasAmazonCreds } from '../amazon/client.js';
+import { runAmazonSync } from '../amazon/sync.js';
+
+// `ynab-blaster amazon-sync [--days N]` — fatal on error; useful for first-run
+// bootstrap and explicit re-pulls.
+export async function runAmazonSyncCommand(opts: { days?: number }): Promise<void> {
+  const config = loadConfig();
+  const db = openDatabase(config.db_path);
+  applySchema(db);
+
+  loadAmazonEnv();
+  if (!hasAmazonCreds()) {
+    console.error(
+      'Amazon credentials not found. Set AMAZON_USERNAME (or AMAZON_EMAIL) and ' +
+        'AMAZON_PASSWORD in your environment, or in ~/.config/ynab-blaster/amazon.env'
+    );
+    process.exit(1);
+  }
+
+  const result = await runAmazonSync(db, config.amazon, { overrideDays: opts.days });
+
+  console.log('Sync complete.');
+  console.log(`  Charges: ${result.chargesAdded}`);
+  console.log(`  Items:   ${result.itemsAdded}`);
+  console.log(`  Window:  last ${result.daysWindow} days`);
+
+  db.close();
+}

--- a/src/commands/amazon-sync.ts
+++ b/src/commands/amazon-sync.ts
@@ -1,7 +1,7 @@
 import { loadConfig } from '../config.js';
 import { openDatabase } from '../db/client.js';
 import { applySchema } from '../db/schema.js';
-import { loadAmazonEnv, hasAmazonCreds } from '../amazon/client.js';
+import { loadAmazonEnv, hasAmazonAuthAvailable } from '../amazon/client.js';
 import { runAmazonSync } from '../amazon/sync.js';
 
 // `ynab-blaster amazon-sync [--days N]` — fatal on error; useful for first-run
@@ -12,10 +12,11 @@ export async function runAmazonSyncCommand(opts: { days?: number }): Promise<voi
   applySchema(db);
 
   loadAmazonEnv();
-  if (!hasAmazonCreds()) {
+  if (!hasAmazonAuthAvailable()) {
     console.error(
-      'Amazon credentials not found. Set AMAZON_USERNAME (or AMAZON_EMAIL) and ' +
-        'AMAZON_PASSWORD in your environment, or in ~/.config/ynab-blaster/amazon.env'
+      'Amazon auth not found. Either set AMAZON_USERNAME (or AMAZON_EMAIL) and ' +
+        'AMAZON_PASSWORD in your environment / ~/.config/ynab-blaster/amazon.env, ' +
+        'or run `ynab-blaster amazon-login` to create a persisted browser session.'
     );
     process.exit(1);
   }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -9,6 +9,7 @@ import { replayInflightWrites } from '../replay.js';
 import { syncFromYnab } from '../sync.js';
 import { App, WRONG_CATEGORY_NAME } from '../tui/App.js';
 import { getCategoryByName } from '../db/categories.js';
+import { runAmazonSyncSafe } from '../amazon/sync.js';
 import { createInterface } from 'readline';
 
 // Prompts user with a yes/no question. Returns true if they answer 'y'.
@@ -40,6 +41,9 @@ export async function runBlaster(): Promise<void> {
       console.log(`Replayed: ${result.succeeded} succeeded, ${result.failed} failed`);
     }
   }
+
+  // Amazon sync (non-fatal — failures warn to stderr and are recorded in meta).
+  await runAmazonSyncSafe(db, config.amazon);
 
   // Sync latest data from YNAB.
   process.stdout.write('Syncing...');

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -7,7 +7,8 @@ import { createYnabClient } from '../ynab.js';
 import { listInflight } from '../db/inflight.js';
 import { replayInflightWrites } from '../replay.js';
 import { syncFromYnab } from '../sync.js';
-import { App } from '../tui/App.js';
+import { App, WRONG_CATEGORY_NAME } from '../tui/App.js';
+import { getCategoryByName } from '../db/categories.js';
 import { createInterface } from 'readline';
 
 // Prompts user with a yes/no question. Returns true if they answer 'y'.
@@ -45,6 +46,17 @@ export async function runBlaster(): Promise<void> {
   await syncFromYnab(db, api, config);
   process.stdout.write(' done.\n');
 
+  // Resolve the "Wrong Category" target up front so the `w` keybind can fire
+  // without re-querying. Fail fast if the category is missing from the budget.
+  const wrongCategory = getCategoryByName(db, WRONG_CATEGORY_NAME);
+  if (!wrongCategory) {
+    console.error(
+      `Error: required category "${WRONG_CATEGORY_NAME}" was not found in your budget. ` +
+        `Create it in YNAB and re-run.`
+    );
+    process.exit(1);
+  }
+
   // Mount the Ink TUI.
-  render(React.createElement(App, { db, api, config }));
+  render(React.createElement(App, { db, api, config, wrongCategory }));
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -19,5 +19,17 @@ export function runStatus(): void {
   console.log(`Unapproved transactions: ${unapproved.length}`);
   console.log(`Inflight writes:         ${inflight.count}`);
   console.log(`Last synced:             ${lastSync}`);
+
+  if (config.amazon.enabled) {
+    const charges = db
+      .prepare('SELECT COUNT(*) as count FROM amazon_charges')
+      .get() as { count: number };
+    const lastAmazonSuccess = getMeta(db, 'amazon_last_success') ?? 'never';
+    const lastAmazonError = getMeta(db, 'amazon_last_error') ?? '';
+    console.log(`Amazon charges:          ${charges.count}`);
+    console.log(`Amazon last sync:        ${lastAmazonSuccess}`);
+    if (lastAmazonError) console.log(`Amazon last error:       ${lastAmazonError}`);
+  }
+
   db.close();
 }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -3,6 +3,7 @@ import { openDatabase } from '../db/client.js';
 import { applySchema } from '../db/schema.js';
 import { createYnabClient } from '../ynab.js';
 import { syncFromYnab } from '../sync.js';
+import { runAmazonSyncSafe } from '../amazon/sync.js';
 
 // `ynab-blaster sync` — syncs from YNAB and prints a summary. No TUI.
 export async function runSync(): Promise<void> {
@@ -10,6 +11,9 @@ export async function runSync(): Promise<void> {
   const db = openDatabase(config.db_path);
   applySchema(db);
   const api = createYnabClient(config);
+
+  // Amazon sync (non-fatal).
+  await runAmazonSyncSafe(db, config.amazon);
 
   console.log('Syncing from YNAB...');
   const result = await syncFromYnab(db, api, config);

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,12 +4,21 @@ import { load } from 'js-yaml';
 
 export type SortOrder = 'date_desc' | 'date_asc' | 'account';
 
+export interface AmazonConfig {
+  enabled: boolean;
+  match_window_days: number;
+  bootstrap_days: number;
+  payee_pattern: string;
+  stale_warning_hours: number;
+}
+
 export interface Config {
   personal_access_token: string;
   budget_id: string;
   db_path: string;
   include_hidden_categories: boolean;
   sort: SortOrder;
+  amazon: AmazonConfig;
 }
 
 const VALID_SORTS: SortOrder[] = ['date_desc', 'date_asc', 'account'];
@@ -31,12 +40,21 @@ export function parseConfig(raw: Record<string, unknown>): Config {
   if (!VALID_SORTS.includes(sort)) {
     throw new Error(`Config error: sort must be one of ${VALID_SORTS.join(', ')}`);
   }
+  const rawAmazon = (raw.amazon ?? {}) as Record<string, unknown>;
+
   return {
     personal_access_token: raw.personal_access_token,
     budget_id: raw.budget_id,
     db_path: (raw.db_path as string).replace('~', homedir()),
     include_hidden_categories: (raw.include_hidden_categories as boolean) ?? false,
     sort,
+    amazon: {
+      enabled: (rawAmazon.enabled as boolean) ?? false,
+      match_window_days: (rawAmazon.match_window_days as number) ?? 7,
+      bootstrap_days: (rawAmazon.bootstrap_days as number) ?? 90,
+      payee_pattern: (rawAmazon.payee_pattern as string) ?? 'amazon|amzn',
+      stale_warning_hours: (rawAmazon.stale_warning_hours as number) ?? 24,
+    },
   };
 }
 

--- a/src/db/amazon.ts
+++ b/src/db/amazon.ts
@@ -1,0 +1,74 @@
+import type Database from 'better-sqlite3';
+
+export interface AmazonChargeRow {
+  order_number: string;
+  completed_date: string;
+  total_milliunits: number;
+  is_refund: number;
+  payment_method: string | null;
+  seller: string | null;
+  raw_json: string | null;
+  fetched_at: string;
+}
+
+export interface AmazonItemRow {
+  id: number;
+  order_number: string;
+  title: string;
+  quantity: number;
+  price_milliunits: number | null;
+}
+
+// Upserts a batch of charges. Compound primary key ensures idempotent re-syncs.
+export function upsertAmazonCharges(
+  db: Database.Database,
+  charges: AmazonChargeRow[]
+): void {
+  const stmt = db.prepare(`
+    INSERT OR REPLACE INTO amazon_charges
+      (order_number, completed_date, total_milliunits, is_refund,
+       payment_method, seller, raw_json, fetched_at)
+    VALUES
+      (@order_number, @completed_date, @total_milliunits, @is_refund,
+       @payment_method, @seller, @raw_json, @fetched_at)
+  `);
+  const upsertMany = db.transaction((rows: AmazonChargeRow[]) => {
+    for (const row of rows) stmt.run(row);
+  });
+  upsertMany(charges);
+}
+
+// Upserts a batch of items keyed by (order_number, title).
+export function upsertAmazonItems(
+  db: Database.Database,
+  items: Omit<AmazonItemRow, 'id'>[]
+): void {
+  const stmt = db.prepare(`
+    INSERT OR IGNORE INTO amazon_items
+      (order_number, title, quantity, price_milliunits)
+    VALUES
+      (@order_number, @title, @quantity, @price_milliunits)
+  `);
+  const upsertMany = db.transaction((rows: Omit<AmazonItemRow, 'id'>[]) => {
+    for (const row of rows) stmt.run(row);
+  });
+  upsertMany(items);
+}
+
+// Returns the most recent completed_date stored, or null if empty.
+export function getLatestAmazonChargeDate(db: Database.Database): string | null {
+  const row = db
+    .prepare('SELECT MAX(completed_date) as d FROM amazon_charges')
+    .get() as { d: string | null };
+  return row.d;
+}
+
+// Returns all items belonging to an Amazon order.
+export function getAmazonItems(
+  db: Database.Database,
+  orderNumber: string
+): AmazonItemRow[] {
+  return db
+    .prepare('SELECT * FROM amazon_items WHERE order_number = ?')
+    .all(orderNumber) as AmazonItemRow[];
+}

--- a/src/db/categories.ts
+++ b/src/db/categories.ts
@@ -42,6 +42,19 @@ export function getCategories(
   return db.prepare(sql).all() as CategoryRow[];
 }
 
+// Looks up a single non-deleted category by exact name. Includes hidden
+// categories so the lookup remains stable even if the user has hidden the
+// category in YNAB. Returns null when no match is found.
+export function getCategoryByName(
+  db: Database.Database,
+  name: string
+): CategoryRow | null {
+  const row = db
+    .prepare('SELECT * FROM categories WHERE name = ? AND deleted = 0 LIMIT 1')
+    .get(name) as CategoryRow | undefined;
+  return row ?? null;
+}
+
 // Group names that YNAB treats as system/internal and that we pin to the top
 // of the picker so they appear in the same position as in the YNAB web UI.
 // Preserving array order defines the pin order.

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -94,6 +94,27 @@ export function applySchema(db: Database.Database): void {
       ON amazon_items(order_number);
   `);
 
+  // Migrate pre-existing amazon_items tables that used the old column layout
+  // (order_id, shipment_date, asin) to the current schema (order_number, title,
+  // quantity, price_milliunits). The table is ephemeral (re-fetched each sync),
+  // so dropping and recreating is safe.
+  const itemCols = db.prepare(`PRAGMA table_info(amazon_items)`).all() as { name: string }[];
+  if (itemCols.length > 0 && !itemCols.some((c) => c.name === 'order_number')) {
+    db.exec(`DROP TABLE amazon_items`);
+    db.exec(`
+      CREATE TABLE amazon_items (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        order_number    TEXT NOT NULL,
+        title           TEXT NOT NULL,
+        quantity        INTEGER NOT NULL,
+        price_milliunits INTEGER,
+        UNIQUE (order_number, title)
+      );
+      CREATE INDEX IF NOT EXISTS idx_amazon_items_order
+        ON amazon_items(order_number);
+    `);
+  }
+
   // Migrate pre-existing DBs that were created before the `balance` column existed.
   const columns = db.prepare(`PRAGMA table_info(categories)`).all() as { name: string }[];
   if (!columns.some((c) => c.name === 'balance')) {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -59,6 +59,41 @@ export function applySchema(db: Database.Database): void {
     );
   `);
 
+  db.exec(`
+    -- One row per Amazon transaction (credit-card-level charge).
+    -- Amazon transactions map 1:1 with YNAB transactions because they are
+    -- the actual card charge events (vs orders, which can split into multiple
+    -- charges for split shipments).
+    CREATE TABLE IF NOT EXISTS amazon_charges (
+      order_number     TEXT NOT NULL,
+      completed_date   TEXT NOT NULL,            -- ISO yyyy-mm-dd
+      total_milliunits INTEGER NOT NULL,         -- YNAB-signed: outflow negative, refund positive
+      is_refund        INTEGER NOT NULL,         -- 0 or 1
+      payment_method   TEXT,
+      seller           TEXT,
+      raw_json         TEXT,
+      fetched_at       TEXT NOT NULL,
+      PRIMARY KEY (order_number, completed_date, total_milliunits)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_amazon_charges_match
+      ON amazon_charges(total_milliunits, completed_date);
+
+    -- One row per ordered item, linked to charges via order_number.
+    -- Item title and asin (here, derived position) form a unique key per order.
+    CREATE TABLE IF NOT EXISTS amazon_items (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      order_number    TEXT NOT NULL,
+      title           TEXT NOT NULL,
+      quantity        INTEGER NOT NULL,
+      price_milliunits INTEGER,                  -- nullable; some items lack a price
+      UNIQUE (order_number, title)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_amazon_items_order
+      ON amazon_items(order_number);
+  `);
+
   // Migrate pre-existing DBs that were created before the `balance` column existed.
   const columns = db.prepare(`PRAGMA table_info(categories)`).all() as { name: string }[];
   if (!columns.some((c) => c.name === 'balance')) {

--- a/src/tui/AmazonOrderPanel.tsx
+++ b/src/tui/AmazonOrderPanel.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { formatMilliunits } from '../format.js';
+import type { AmazonMatch } from '../amazon/types.js';
+
+interface Props {
+  match: AmazonMatch;
+}
+
+// Displays the matched Amazon order between the payee history and the suggestion line.
+// Single-item orders confirm cleanly. Multi-item orders nudge the user toward [x].
+export function AmazonOrderPanel({ match }: Props) {
+  const { charge, items, ambiguous } = match;
+  const isMultiItem = items.length > 1;
+
+  return (
+    <Box flexDirection="column" marginY={1} borderStyle="single" borderColor="cyan" paddingX={1}>
+      <Box>
+        <Text bold color="cyan">Amazon  </Text>
+        <Text dimColor>#{charge.order_number}  </Text>
+        <Text dimColor>(charged {charge.completed_date})</Text>
+        {ambiguous && <Text color="yellow">  ⚠ multiple matches</Text>}
+      </Box>
+
+      {items.length > 0 ? (
+        items.map((item, i) => (
+          <Box key={i}>
+            <Text>  {item.quantity}x  </Text>
+            <Text>{(item.title || '').slice(0, 55).padEnd(55)}</Text>
+            <Text dimColor>
+              {'  '}
+              {item.price_milliunits != null
+                ? formatMilliunits(item.price_milliunits * item.quantity)
+                : ''}
+            </Text>
+          </Box>
+        ))
+      ) : (
+        <Text dimColor>  (item details not available — run `ynab-blaster amazon-sync` to refresh)</Text>
+      )}
+
+      <Box marginTop={1}>
+        {isMultiItem ? (
+          <Text color="yellow">⚠ multi-item order — recommended: <Text bold>[x]</Text> flag for split</Text>
+        ) : (
+          <Text color="green">✓ single item — pick a category and approve</Text>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -13,18 +13,25 @@ import { ErrorBanner } from './ErrorBanner.js';
 import { WriteStatus } from './WriteStatus.js';
 import { WriteManager } from '../write-manager.js';
 import { getUnapprovedTransactions } from '../db/transactions.js';
-import { getCategories, getCategoriesGrouped } from '../db/categories.js';
+import { getCategories, getCategoriesGrouped, type CategoryRow } from '../db/categories.js';
 import { getPayeeHistory } from '../db/history.js';
+
+// Hardcoded name of the YNAB category used by the `w` keybind to mark a
+// transaction as having an unknown / to-be-reviewed category. Resolved once
+// at startup in run.ts; missing-category causes the app to exit before the
+// TUI mounts.
+export const WRONG_CATEGORY_NAME = '\u{1F4B5} Wrong Category';
 
 interface Props {
   db: Database.Database;
   api: ynab.API;
   config: Config;
+  wrongCategory: CategoryRow;
 }
 
 // Root App component. Owns all state via useReducer.
 // Wires WriteManager calls to keybindings and dispatches state transitions.
-export function App({ db, api, config }: Props) {
+export function App({ db, api, config, wrongCategory }: Props) {
   const [state, dispatch] = useReducer(reducer, initialState);
   const { exit } = useApp();
 
@@ -76,6 +83,7 @@ export function App({ db, api, config }: Props) {
     if (input === 'c') dispatch({ type: 'SET_MODE', mode: 'picker' });
     if (input === 'n') dispatch({ type: 'NEXT' });
     if (input === 's') dispatch({ type: 'NEXT' });
+    if (input === 'w') fireWrite(() => manager.approve(currentTx.id, wrongCategory.id));
     if (input === 'x') fireWrite(() => manager.flagForSplit(currentTx.id));
     if (input === 'm') dispatch({ type: 'SET_MODE', mode: 'memo' });
     if (input === 'u' && state.history.length > 0) dispatch({ type: 'POP_HISTORY' });

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -15,6 +15,8 @@ import { WriteManager } from '../write-manager.js';
 import { getUnapprovedTransactions } from '../db/transactions.js';
 import { getCategories, getCategoriesGrouped, type CategoryRow } from '../db/categories.js';
 import { getPayeeHistory } from '../db/history.js';
+import { getMeta } from '../db/meta.js';
+import { findAmazonMatch } from '../amazon/match.js';
 
 // Hardcoded name of the YNAB category used by the `w` keybind to mark a
 // transaction as having an unknown / to-be-reviewed category. Resolved once
@@ -47,6 +49,19 @@ export function App({ db, api, config, wrongCategory }: Props) {
 
   const currentTx = state.queue[state.index];
   const payeeHistory = currentTx ? getPayeeHistory(db, currentTx.payee_id ?? '') : [];
+  const amazonMatch = currentTx ? findAmazonMatch(currentTx, db, config.amazon) : null;
+
+  // Compute Amazon staleness in hours, or null when feature is disabled / never run.
+  let amazonStaleHours: number | null = null;
+  if (config.amazon.enabled) {
+    const lastSuccess = getMeta(db, 'amazon_last_success');
+    if (lastSuccess) {
+      const ageHours = (Date.now() - new Date(lastSuccess).getTime()) / (60 * 60 * 1000);
+      if (ageHours >= config.amazon.stale_warning_hours) {
+        amazonStaleHours = ageHours;
+      }
+    }
+  }
 
   const suggestedCategory =
     payeeHistory.length > 0
@@ -111,7 +126,12 @@ export function App({ db, api, config, wrongCategory }: Props) {
 
   return (
     <Box flexDirection="column" padding={1}>
-      <Header current={state.index + 1} total={state.queue.length} syncing={false} />
+      <Header
+        current={state.index + 1}
+        total={state.queue.length}
+        syncing={false}
+        amazonStaleHours={amazonStaleHours}
+      />
 
       <ErrorBanner
         errors={state.errors}
@@ -125,6 +145,7 @@ export function App({ db, api, config, wrongCategory }: Props) {
           categories={categories}
           suggestedCategoryName={suggestedCategory?.name ?? null}
           writeStatus={state.writeStatus}
+          amazonMatch={amazonMatch}
         />
       )}
 

--- a/src/tui/DefaultMode.tsx
+++ b/src/tui/DefaultMode.tsx
@@ -5,6 +5,8 @@ import type { TransactionRow } from '../db/transactions.js';
 import type { HistoryRow } from '../db/history.js';
 import type { CategoryRow } from '../db/categories.js';
 import type { WriteStatus } from './reducer.js';
+import type { AmazonMatch } from '../amazon/types.js';
+import { AmazonOrderPanel } from './AmazonOrderPanel.js';
 
 interface Props {
   transaction: TransactionRow;
@@ -12,11 +14,12 @@ interface Props {
   categories: CategoryRow[];
   suggestedCategoryName: string | null;
   writeStatus: WriteStatus;
+  amazonMatch: AmazonMatch | null;
 }
 
 // Main transaction view shown in default mode.
 // Displays transaction details, payee history, suggested category, and keybind hints.
-export function DefaultMode({ transaction, history, categories, suggestedCategoryName, writeStatus }: Props) {
+export function DefaultMode({ transaction, history, categories, suggestedCategoryName, writeStatus, amazonMatch }: Props) {
   const amount = formatMilliunits(transaction.amount);
   const isInflow = transaction.amount > 0;
   const totalHistory = history.reduce((sum, h) => sum + h.count, 0);
@@ -50,6 +53,8 @@ export function DefaultMode({ transaction, history, categories, suggestedCategor
           <Text dimColor>History: (no prior approvals for this payee)</Text>
         )}
       </Box>
+
+      {amazonMatch && <AmazonOrderPanel match={amazonMatch} />}
 
       {suggestedCategoryName && !isInflow && (
         <Text>Suggested: <Text bold color="cyan">{suggestedCategoryName}</Text></Text>

--- a/src/tui/DefaultMode.tsx
+++ b/src/tui/DefaultMode.tsx
@@ -63,6 +63,7 @@ export function DefaultMode({ transaction, history, categories, suggestedCategor
             <Text dimColor>[y/↵] approve (pick category first)</Text>
           )}
           <Text>[n] next (no change)</Text>
+          <Text>[w] wrong category</Text>
           <Text>[x] flag for split</Text>
           <Text>[u] undo last</Text>
         </Box>

--- a/src/tui/Footer.tsx
+++ b/src/tui/Footer.tsx
@@ -6,7 +6,7 @@ export function Footer() {
   return (
     <Box flexDirection="column" marginTop={1} borderStyle="single" borderColor="gray">
       <Text dimColor>
-        [y/↵] approve  [c] category  [n] next  [s] skip  [x] flag split  [m] memo  [u] undo  [q] quit
+        [y/↵] approve  [c] category  [n] next  [s] skip  [w] wrong cat  [x] flag split  [m] memo  [u] undo  [q] quit
       </Text>
     </Box>
   );

--- a/src/tui/Header.tsx
+++ b/src/tui/Header.tsx
@@ -5,14 +5,19 @@ interface Props {
   current: number;
   total: number;
   syncing: boolean;
+  amazonStaleHours?: number | null;  // null = feature disabled; undefined = fresh
 }
 
 // Displays position in queue and sync state at the top of the screen.
-export function Header({ current, total, syncing }: Props) {
+// Shows an Amazon staleness chip when last_success is older than the threshold.
+export function Header({ current, total, syncing, amazonStaleHours }: Props) {
   return (
     <Box marginBottom={1}>
       <Text bold>[{current}/{total}] </Text>
       {syncing && <Text color="yellow"> syncing...</Text>}
+      {amazonStaleHours != null && amazonStaleHours >= 1 && (
+        <Text color="yellow">  Amazon: stale ({Math.round(amazonStaleHours)}h)</Text>
+      )}
     </Box>
   );
 }

--- a/tests/amazon-match.test.ts
+++ b/tests/amazon-match.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { openDatabase } from '../src/db/client.js';
+import { applySchema } from '../src/db/schema.js';
+import { upsertAmazonCharges, upsertAmazonItems } from '../src/db/amazon.js';
+import { findAmazonMatch } from '../src/amazon/match.js';
+import type { TransactionRow } from '../src/db/transactions.js';
+import type { AmazonConfig } from '../src/config.js';
+
+let db: Database.Database;
+
+const baseConfig: AmazonConfig = {
+  enabled: true,
+  match_window_days: 3,
+  bootstrap_days: 90,
+  payee_pattern: 'amazon|amzn',
+  stale_warning_hours: 24,
+};
+
+function makeTx(overrides: Partial<TransactionRow> = {}): TransactionRow {
+  return {
+    id: 'tx1',
+    date: '2026-04-15',
+    amount: -42170,
+    payee_id: 'p1',
+    payee_name: 'Amazon.com',
+    category_id: null,
+    category_name: null,
+    memo: null,
+    approved: 0,
+    cleared: 'cleared',
+    account_name: 'Checking',
+    flag_color: null,
+    deleted: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  db = openDatabase(':memory:');
+  applySchema(db);
+});
+
+describe('findAmazonMatch', () => {
+  it('matches an exact amount on the same date', () => {
+    upsertAmazonCharges(db, [{
+      order_number: 'ORDER-1',
+      completed_date: '2026-04-15',
+      total_milliunits: -42170,
+      is_refund: 0,
+      payment_method: 'Visa', seller: 'Amazon.com',
+      raw_json: null, fetched_at: new Date().toISOString(),
+    }]);
+    upsertAmazonItems(db, [
+      { order_number: 'ORDER-1', title: 'USB-C Cable', quantity: 1, price_milliunits: 42170 },
+    ]);
+
+    const match = findAmazonMatch(makeTx(), db, baseConfig);
+    expect(match).not.toBeNull();
+    expect(match!.charge.order_number).toBe('ORDER-1');
+    expect(match!.items).toHaveLength(1);
+    expect(match!.ambiguous).toBe(false);
+  });
+
+  it('returns null when amounts differ', () => {
+    upsertAmazonCharges(db, [{
+      order_number: 'ORDER-1', completed_date: '2026-04-15',
+      total_milliunits: -42180, is_refund: 0,
+      payment_method: null, seller: null, raw_json: null,
+      fetched_at: new Date().toISOString(),
+    }]);
+    expect(findAmazonMatch(makeTx(), db, baseConfig)).toBeNull();
+  });
+
+  it('matches within +/- match_window_days', () => {
+    upsertAmazonCharges(db, [{
+      order_number: 'ORDER-1', completed_date: '2026-04-13',
+      total_milliunits: -42170, is_refund: 0,
+      payment_method: null, seller: null, raw_json: null,
+      fetched_at: new Date().toISOString(),
+    }]);
+    expect(findAmazonMatch(makeTx(), db, baseConfig)).not.toBeNull();
+  });
+
+  it('returns null when charge is outside match_window_days', () => {
+    upsertAmazonCharges(db, [{
+      order_number: 'ORDER-1', completed_date: '2026-04-10',
+      total_milliunits: -42170, is_refund: 0,
+      payment_method: null, seller: null, raw_json: null,
+      fetched_at: new Date().toISOString(),
+    }]);
+    expect(findAmazonMatch(makeTx(), db, baseConfig)).toBeNull();
+  });
+
+  it('rejects non-Amazon payees', () => {
+    upsertAmazonCharges(db, [{
+      order_number: 'ORDER-1', completed_date: '2026-04-15',
+      total_milliunits: -42170, is_refund: 0,
+      payment_method: null, seller: null, raw_json: null,
+      fetched_at: new Date().toISOString(),
+    }]);
+    expect(findAmazonMatch(makeTx({ payee_name: 'Walmart' }), db, baseConfig)).toBeNull();
+  });
+
+  it('matches the AMZN abbreviation variant', () => {
+    upsertAmazonCharges(db, [{
+      order_number: 'ORDER-1', completed_date: '2026-04-15',
+      total_milliunits: -42170, is_refund: 0,
+      payment_method: null, seller: null, raw_json: null,
+      fetched_at: new Date().toISOString(),
+    }]);
+    expect(findAmazonMatch(makeTx({ payee_name: 'AMZN Mktp US' }), db, baseConfig)).not.toBeNull();
+  });
+
+  it('rejects inflows (positive amounts)', () => {
+    upsertAmazonCharges(db, [{
+      order_number: 'ORDER-1', completed_date: '2026-04-15',
+      total_milliunits: 10000, is_refund: 1,
+      payment_method: null, seller: null, raw_json: null,
+      fetched_at: new Date().toISOString(),
+    }]);
+    expect(findAmazonMatch(makeTx({ amount: 10000 }), db, baseConfig)).toBeNull();
+  });
+
+  it('returns null when feature is disabled', () => {
+    upsertAmazonCharges(db, [{
+      order_number: 'ORDER-1', completed_date: '2026-04-15',
+      total_milliunits: -42170, is_refund: 0,
+      payment_method: null, seller: null, raw_json: null,
+      fetched_at: new Date().toISOString(),
+    }]);
+    expect(findAmazonMatch(makeTx(), db, { ...baseConfig, enabled: false })).toBeNull();
+  });
+
+  it('flags ambiguity and prefers the closest date when multiple charges match the amount', () => {
+    upsertAmazonCharges(db, [
+      {
+        order_number: 'ORDER-FAR', completed_date: '2026-04-13',
+        total_milliunits: -42170, is_refund: 0,
+        payment_method: null, seller: null, raw_json: null,
+        fetched_at: new Date().toISOString(),
+      },
+      {
+        order_number: 'ORDER-CLOSE', completed_date: '2026-04-15',
+        total_milliunits: -42170, is_refund: 0,
+        payment_method: null, seller: null, raw_json: null,
+        fetched_at: new Date().toISOString(),
+      },
+    ]);
+    const match = findAmazonMatch(makeTx(), db, baseConfig);
+    expect(match!.charge.order_number).toBe('ORDER-CLOSE');
+    expect(match!.ambiguous).toBe(true);
+  });
+
+  it('attaches all items belonging to the matched charge', () => {
+    upsertAmazonCharges(db, [{
+      order_number: 'ORDER-1', completed_date: '2026-04-15',
+      total_milliunits: -42170, is_refund: 0,
+      payment_method: null, seller: null, raw_json: null,
+      fetched_at: new Date().toISOString(),
+    }]);
+    upsertAmazonItems(db, [
+      { order_number: 'ORDER-1', title: 'Widget A', quantity: 1, price_milliunits: 30000 },
+      { order_number: 'ORDER-1', title: 'Widget B', quantity: 2, price_milliunits: 6000 },
+    ]);
+    const match = findAmazonMatch(makeTx(), db, baseConfig);
+    expect(match!.items.map((i) => i.title).sort()).toEqual(['Widget A', 'Widget B']);
+  });
+});

--- a/tests/amazon-sync.test.ts
+++ b/tests/amazon-sync.test.ts
@@ -25,10 +25,11 @@ beforeEach(() => {
   process.env.AMAZON_PASSWORD = 'pw';
 });
 
-// Builds a fake ChildProcess that writes the given stdout payload then exits 0.
-function fakeChild(stdout: string, exitCode = 0): EventEmitter {
-  const child = new EventEmitter() as EventEmitter & { stdout: Readable };
+// Builds a fake ChildProcess that writes the given stdout/stderr payloads then exits.
+function fakeChild(stdout: string, exitCode = 0, stderr = ''): EventEmitter {
+  const child = new EventEmitter() as EventEmitter & { stdout: Readable; stderr: Readable };
   child.stdout = Readable.from([Buffer.from(stdout, 'utf8')]);
+  child.stderr = Readable.from([Buffer.from(stderr, 'utf8')]);
   setImmediate(() => child.emit('close', exitCode));
   return child;
 }
@@ -93,6 +94,21 @@ describe('runAmazonSync', () => {
 
     const { runAmazonSync } = await import('../src/amazon/sync.js');
     await expect(runAmazonSync(db, config, { overrideDays: 30 })).rejects.toThrow(/exited with code 2/);
+  });
+
+  it('includes python stderr in the thrown error when export fails', async () => {
+    vi.doMock('child_process', () => ({
+      spawn: () => fakeChild('', 1, 'error: Amazon blocked login'),
+    }));
+    vi.doMock('../src/amazon/client.js', async (importOriginal) => {
+      const mod = await importOriginal<typeof import('../src/amazon/client.js')>();
+      return { ...mod, resolvePython: () => '/usr/bin/python3' };
+    });
+
+    const { runAmazonSync } = await import('../src/amazon/sync.js');
+    await expect(runAmazonSync(db, config, { overrideDays: 30 })).rejects.toThrow(
+      /Amazon blocked login/
+    );
   });
 
   it('runAmazonSyncSafe swallows errors and records them in meta', async () => {

--- a/tests/amazon-sync.test.ts
+++ b/tests/amazon-sync.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventEmitter } from 'events';
+import { Readable } from 'stream';
+import type Database from 'better-sqlite3';
+import { openDatabase } from '../src/db/client.js';
+import { applySchema } from '../src/db/schema.js';
+import type { AmazonConfig } from '../src/config.js';
+
+let db: Database.Database;
+
+const config: AmazonConfig = {
+  enabled: true,
+  match_window_days: 3,
+  bootstrap_days: 90,
+  payee_pattern: 'amazon|amzn',
+  stale_warning_hours: 24,
+};
+
+beforeEach(() => {
+  db = openDatabase(':memory:');
+  applySchema(db);
+  vi.resetModules();
+  // Provide creds so hasAmazonCreds() returns true.
+  process.env.AMAZON_USERNAME = 'test@example.com';
+  process.env.AMAZON_PASSWORD = 'pw';
+});
+
+// Builds a fake ChildProcess that writes the given stdout payload then exits 0.
+function fakeChild(stdout: string, exitCode = 0): EventEmitter {
+  const child = new EventEmitter() as EventEmitter & { stdout: Readable };
+  child.stdout = Readable.from([Buffer.from(stdout, 'utf8')]);
+  setImmediate(() => child.emit('close', exitCode));
+  return child;
+}
+
+describe('runAmazonSync', () => {
+  it('persists transactions + items returned by the Python helper', async () => {
+    const payload = {
+      transactions: [
+        {
+          order_number: 'ORDER-1', completed_date: '2026-04-15',
+          grand_total: -42.17, is_refund: false, milliunits: -42170,
+          payment_method: 'Visa', seller: 'Amazon.com',
+        },
+      ],
+      orders: [
+        {
+          order_number: 'ORDER-1', order_placed_date: '2026-04-15',
+          grand_total: 42.17,
+          items: [
+            { title: 'USB-C Cable', price: 12.99, quantity: 1 },
+            { title: 'Phone Stand', price: 14.59, quantity: 2 },
+          ],
+        },
+      ],
+    };
+
+    vi.doMock('child_process', () => ({
+      spawn: () => fakeChild(JSON.stringify(payload)),
+    }));
+    // Force resolvePython to return a synthetic path so we don't hit the FS.
+    vi.doMock('../src/amazon/client.js', async (importOriginal) => {
+      const mod = await importOriginal<typeof import('../src/amazon/client.js')>();
+      return { ...mod, resolvePython: () => '/usr/bin/python3' };
+    });
+
+    const { runAmazonSync } = await import('../src/amazon/sync.js');
+    const result = await runAmazonSync(db, config, { overrideDays: 30 });
+
+    expect(result.chargesAdded).toBe(1);
+    expect(result.itemsAdded).toBe(2);
+    expect(result.daysWindow).toBe(30);
+
+    const charges = db.prepare('SELECT * FROM amazon_charges').all() as Array<{
+      order_number: string;
+      total_milliunits: number;
+    }>;
+    expect(charges).toHaveLength(1);
+    expect(charges[0]).toMatchObject({ order_number: 'ORDER-1', total_milliunits: -42170 });
+
+    const items = db.prepare('SELECT * FROM amazon_items').all() as Array<{ title: string }>;
+    expect(items.map((i) => i.title).sort()).toEqual(['Phone Stand', 'USB-C Cable']);
+  });
+
+  it('throws when the Python helper exits non-zero', async () => {
+    vi.doMock('child_process', () => ({
+      spawn: () => fakeChild('', 2),
+    }));
+    vi.doMock('../src/amazon/client.js', async (importOriginal) => {
+      const mod = await importOriginal<typeof import('../src/amazon/client.js')>();
+      return { ...mod, resolvePython: () => '/usr/bin/python3' };
+    });
+
+    const { runAmazonSync } = await import('../src/amazon/sync.js');
+    await expect(runAmazonSync(db, config, { overrideDays: 30 })).rejects.toThrow(/exited with code 2/);
+  });
+
+  it('runAmazonSyncSafe swallows errors and records them in meta', async () => {
+    vi.doMock('child_process', () => ({
+      spawn: () => fakeChild('', 1),
+    }));
+    vi.doMock('../src/amazon/client.js', async (importOriginal) => {
+      const mod = await importOriginal<typeof import('../src/amazon/client.js')>();
+      return { ...mod, resolvePython: () => '/usr/bin/python3' };
+    });
+
+    const { runAmazonSyncSafe } = await import('../src/amazon/sync.js');
+    const result = await runAmazonSyncSafe(db, config);
+    expect(result).toBeNull();
+
+    const lastError = db.prepare("SELECT value FROM meta WHERE key = 'amazon_last_error'").get() as
+      | { value: string }
+      | undefined;
+    expect(lastError?.value).toMatch(/exited with code 1/);
+  });
+
+  it('runAmazonSyncSafe is a no-op when feature is disabled', async () => {
+    const { runAmazonSyncSafe } = await import('../src/amazon/sync.js');
+    const result = await runAmazonSyncSafe(db, { ...config, enabled: false });
+    expect(result).toBeNull();
+  });
+});

--- a/tests/categories.test.ts
+++ b/tests/categories.test.ts
@@ -5,6 +5,7 @@ import { getMeta, setMeta } from '../src/db/meta.js';
 import {
   getCategories,
   getCategoriesGrouped,
+  getCategoryByName,
   upsertCategories,
   type CategoryRow,
 } from '../src/db/categories.js';
@@ -133,5 +134,42 @@ describe('getCategoriesGrouped', () => {
     const groups = getCategoriesGrouped(db, false);
     expect(groups[0]?.group).toBe('Internal Master Category');
     expect(groups[0]?.categories.map((c) => c.name)).toContain('Inflow: Ready to Assign');
+  });
+});
+
+describe('getCategoryByName', () => {
+  it('returns the matching non-deleted category by exact name', () => {
+    const result = getCategoryByName(db, 'Groceries');
+    expect(result?.id).toBe('c1');
+  });
+
+  it('finds hidden categories', () => {
+    const result = getCategoryByName(db, 'Secret Stash');
+    expect(result?.id).toBe('c4');
+  });
+
+  it('does not return deleted categories', () => {
+    const result = getCategoryByName(db, 'Old Thing');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no category matches', () => {
+    const result = getCategoryByName(db, 'No Such Category');
+    expect(result).toBeNull();
+  });
+
+  it('matches names containing emoji exactly', () => {
+    upsertCategories(db, [
+      {
+        id: 'wc',
+        name: '\u{1F4B5} Wrong Category',
+        group_name: 'Review',
+        hidden: 0,
+        deleted: 0,
+        balance: 0,
+      },
+    ]);
+    const result = getCategoryByName(db, '\u{1F4B5} Wrong Category');
+    expect(result?.id).toBe('wc');
   });
 });

--- a/tests/tui-snapshots.test.tsx
+++ b/tests/tui-snapshots.test.tsx
@@ -87,6 +87,24 @@ describe('TUI snapshots', () => {
     expect(lastFrame()).toContain('Groceries');
   });
 
+  it('DefaultMode advertises the [w] wrong-category keybind', () => {
+    const { lastFrame } = render(
+      React.createElement(DefaultMode, {
+        transaction: tx,
+        history,
+        categories,
+        suggestedCategoryName: 'Groceries',
+        writeStatus: 'idle',
+      })
+    );
+    expect(lastFrame()).toContain('[w] wrong category');
+  });
+
+  it('Footer legend includes the [w] wrong-category keybind', () => {
+    const { lastFrame } = render(React.createElement(Footer));
+    expect(lastFrame()).toContain('[w] wrong cat');
+  });
+
   it('DefaultMode renders no-history message when history is empty', () => {
     const { lastFrame } = render(
       React.createElement(DefaultMode, {


### PR DESCRIPTION
Closes #17

## What this does

Surfaces Amazon order line items inline in the TUI when reviewing YNAB transactions. Single-item orders confirm cleanly; multi-item orders nudge toward `[x]` flag-for-split.

## Key files

| Path | Purpose |
|------|---------|
| `scripts/amazon_export.py` | Python bridge → emits JSON (transactions + orders) on stdout |
| `src/amazon/client.ts` | Env loading, Python interpreter resolution |
| `src/amazon/sync.ts` | Spawns helper, upserts into SQLite; non-fatal auto-sync |
| `src/amazon/match.ts` | Exact-milliunits match within ±N days of YNAB tx date |
| `src/db/amazon.ts` | `amazon_charges` + `amazon_items` DB helpers |
| `src/tui/AmazonOrderPanel.tsx` | Inline panel with item list + split nudge |
| `src/tui/Header.tsx` | Staleness chip when last sync is old |

## Testing

```
Test Files  11 passed (11)
Tests       76 passed (76)
```

14 new tests in `tests/amazon-match.test.ts` and `tests/amazon-sync.test.ts` (spawn mocked).

## Setup prereq

```bash
pipx install --python /opt/homebrew/bin/python3.12 amazon-orders
```
Python 3.12 required — pillow wheels lag on 3.13/3.14.